### PR TITLE
Fix skipping of text nodes in markdown parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "basalt-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dirs",
  "indoc",

--- a/basalt-core/CHANGELOG.md
+++ b/basalt-core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.2 (2025-02-27)
+
+### Added
+
+- [Add blank implementations for `TextNode` and `Text`](https://github.com/erikjuhani/basalt/commit/a252f62930ec59f21255d08278762734eb312cef)
+
+### Fixed
+
+- [Fix skipping text nodes in markdown parser](https://github.com/erikjuhani/basalt/commit/3bc112edd2b452ea7093d0e71fcfa0d02bc0b9c4)
+
 ## 0.2.1 (2025-02-23)
 
 ### Added

--- a/basalt-core/Cargo.toml
+++ b/basalt-core/Cargo.toml
@@ -6,7 +6,7 @@ Provides the core functionality for Basalt TUI application
 readme = "README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/basalt-core/src/markdown.rs
+++ b/basalt-core/src/markdown.rs
@@ -432,9 +432,7 @@ impl<'a> Parser<'a> {
             | Tag::MetadataBlock(_)
             | Tag::DefinitionList
             | Tag::DefinitionListTitle
-            | Tag::DefinitionListDefinition => self.push_node(Node::Paragraph {
-                text: Text::default(),
-            }),
+            | Tag::DefinitionListDefinition => {}
         }
     }
 
@@ -603,24 +601,6 @@ mod tests {
                     h6("Heading 6"),
                 ],
             ),
-            (
-                indoc! {r#"Paragraph
-
-                > BlockQuote
-                >
-                > - List item in BlockQuote
-                "#},
-                vec![
-                    p("Paragraph"),
-                    blockquote(vec![
-                        p("BlockQuote"),
-                        Node::Paragraph {
-                            text: Text::default(),
-                        },
-                        item("List item in BlockQuote"),
-                    ]),
-                ],
-            ),
             // TODO: Implement correct test case when `- [?] ` task item syntax is supported
             // Now we interpret it as a regular paragraph
             (
@@ -637,6 +617,33 @@ mod tests {
                     task("Task"),
                     completed_task("Completed task"),
                     p("[?] Completed task"),
+                ],
+            ),
+            (
+                indoc! {r#"## Quotes
+
+                You _can_ quote text by adding a `>` symbols before the text.
+
+                > Human beings face ever more complex and urgent problems, and their effectiveness in dealing with these problems is a matter that is critical to the stability and continued progress of society.
+                >
+                >- Doug Engelbart, 1961
+                "#},
+                vec![
+                    h2("Quotes"),
+                    Node::Paragraph {
+                        text: vec![
+                            TextNode::new("You ".into(), None),
+                            TextNode::new("can".into(), None),
+                            TextNode::new(" quote text by adding a ".into(), None),
+                            TextNode::new(">".into(), Some(Style::Code)),
+                            TextNode::new(" symbols before the text.".into(), None),
+                        ]
+                        .into(),
+                    },
+                    blockquote(vec![
+                        p("Human beings face ever more complex and urgent problems, and their effectiveness in dealing with these problems is a matter that is critical to the stability and continued progress of society."),
+                        item("Doug Engelbart, 1961")
+                    ]),
                 ],
             ),
         ];

--- a/basalt-core/src/markdown.rs
+++ b/basalt-core/src/markdown.rs
@@ -151,6 +151,21 @@ pub struct TextNode {
     pub style: Option<Style>,
 }
 
+impl From<&str> for TextNode {
+    fn from(value: &str) -> Self {
+        value.to_string().into()
+    }
+}
+
+impl From<String> for TextNode {
+    fn from(value: String) -> Self {
+        Self {
+            content: value,
+            ..Default::default()
+        }
+    }
+}
+
 impl TextNode {
     /// Creates a new [`TextNode`] from `content` and optional [`Style`].
     pub fn new(content: String, style: Option<Style>) -> Self {
@@ -164,7 +179,31 @@ pub struct Text(Vec<TextNode>);
 
 impl From<&str> for Text {
     fn from(value: &str) -> Self {
-        Self(vec![TextNode::new(String::from(value), None)])
+        TextNode::from(value).into()
+    }
+}
+
+impl From<String> for Text {
+    fn from(value: String) -> Self {
+        TextNode::from(value).into()
+    }
+}
+
+impl From<TextNode> for Text {
+    fn from(value: TextNode) -> Self {
+        Self([value].to_vec())
+    }
+}
+
+impl From<Vec<TextNode>> for Text {
+    fn from(value: Vec<TextNode>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&[TextNode]> for Text {
+    fn from(value: &[TextNode]) -> Self {
+        Self(value.to_vec())
     }
 }
 
@@ -477,12 +516,8 @@ impl<'a> Parser<'a> {
 mod tests {
     use indoc::indoc;
 
-    fn text(str: &str) -> Text {
-        Text(vec![TextNode::new(String::from(str), None)])
-    }
-
     fn p(str: &str) -> Node {
-        Node::Paragraph { text: text(str) }
+        Node::Paragraph { text: str.into() }
     }
 
     fn blockquote(nodes: Vec<Node>) -> Node {
@@ -492,28 +527,28 @@ mod tests {
     fn item(str: &str) -> Node {
         Node::Item {
             kind: None,
-            text: text(str),
+            text: str.into(),
         }
     }
 
     fn task(str: &str) -> Node {
         Node::Item {
             kind: Some(ItemKind::Unchecked),
-            text: text(str),
+            text: str.into(),
         }
     }
 
     fn completed_task(str: &str) -> Node {
         Node::Item {
             kind: Some(ItemKind::HardChecked),
-            text: text(str),
+            text: str.into(),
         }
     }
 
     fn heading(level: HeadingLevel, str: &str) -> Node {
         Node::Heading {
             level,
-            text: text(str),
+            text: str.into(),
         }
     }
 


### PR DESCRIPTION
## [Add blank implementations for TextNode and Text](https://github.com/erikjuhani/basalt/commit/a252f62930ec59f21255d08278762734eb312cef)

Add more blanket implementations to cover `&str`, `String` conversions
into `TextNode` and `String` `TextNode`, `Vec<TextNode>` and
`&[TextNode]` for `Text`.

This simplifies the conversions between types. For instance one helper
function `text` from the markdown test module was removed and replaced
with `.into()` calls.

Module: basalt-core
Scope: markdown

## [Fix skipping text nodes in markdown parser](https://github.com/erikjuhani/basalt/commit/3bc112edd2b452ea7093d0e71fcfa0d02bc0b9c4)

Previously, quite naively every 'unhandled' tag was pushed as a new
paragraph node, however, this did not work as expected and actually
might replace the current node, even, if that wasn't the intention.

This happened for example with styled text using emphasis or bold
markers.

This is now fixed and the tags that do not have implementation are not
handled at all as separate nodes, but instead if they contain text. This
text will be pushed to the current node block instead.

New more comprehensive test was also added and replaces the simple block
quote test.

Module: basalt-core
Scope: markdown

## [Bump basalt-core to version 0.2.2](https://github.com/erikjuhani/basalt/commit/dc8d3a91f6a21924d44a9982a5dca474018bd3d0)

Update CHANGELOG.

Module: basalt-core