### PR TITLE
Basalt widgets fix breaking change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,19 +10,6 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "basalt-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41c42c5678fdd8a4f6715eb6a5b6fcb38d4baf302e2fe818a9101710b7a3280"
-dependencies = [
- "dirs",
- "pulldown-cmark",
- "serde",
- "serde_json",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "basalt-core"
 version = "0.3.0"
 dependencies = [
  "dirs",
@@ -37,7 +24,7 @@ dependencies = [
 name = "basalt-widgets"
 version = "0.1.0"
 dependencies = [
- "basalt-core 0.2.2",
+ "basalt-core",
  "ratatui",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "basalt-widgets"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "basalt-core",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,4 @@ members = ["basalt-core", "basalt-widgets"]
 resolver = "2"
 
 [workspace.dependencies]
-# TODO: Enable workspace dependency when basalt-widgets supports the breaking changes
-# basalt-core = { path = "basalt-core", version = "0.2.2" }
-basalt-core = { version = "0.2.2" }
+basalt-core = { path = "basalt-core", version = "0.3.0" }

--- a/basalt-widgets/CHANGELOG.md
+++ b/basalt-widgets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+#### Markdown
+
+- [Fix breaking change and use MarkdownNode instead of Node](https://github.com/erikjuhani/basalt/commit/d86f7d788364475c4679c33c6cac6997858846e7)
+
 ## 0.1.0 (2025-02-28)
 
 ### Added

--- a/basalt-widgets/Cargo.toml
+++ b/basalt-widgets/Cargo.toml
@@ -6,7 +6,7 @@ Provides the custom ratatui widgets for Basalt TUI application
 repository = "https://github.com/erikjuhani/basalt"
 readme = "README.md"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 keywords = ["tui", "markdown", "ratatui"]
 

--- a/basalt-widgets/src/markdown/view.rs
+++ b/basalt-widgets/src/markdown/view.rs
@@ -49,7 +49,7 @@ use ratatui::{
     },
 };
 
-use basalt_core::markdown::{self, HeadingLevel, ItemKind, Node};
+use basalt_core::markdown::{self, HeadingLevel, ItemKind};
 
 use super::state::MarkdownViewState;
 
@@ -168,30 +168,30 @@ impl MarkdownView {
     }
 
     fn render_markdown<'a>(node: markdown::Node, prefix: Span<'a>) -> Vec<Line<'a>> {
-        match node {
-            Node::Paragraph { text } => {
+        match node.markdown_node {
+            markdown::MarkdownNode::Paragraph { text } => {
                 let mut spans = MarkdownView::text_to_spans(text);
                 spans.insert(0, prefix.clone());
                 vec![spans.into(), Line::from(prefix)]
             }
-            Node::Heading { level, text } => [
+            markdown::MarkdownNode::Heading { level, text } => [
                 MarkdownView::heading(level, MarkdownView::text_to_spans(text)),
                 Line::default(),
             ]
             .to_vec(),
-            Node::Item { kind, text } => [
+            markdown::MarkdownNode::Item { kind, text } => [
                 MarkdownView::item(kind, MarkdownView::text_to_spans(text), prefix),
                 Line::default(),
             ]
             .to_vec(),
             // TODO: Add lang support and syntax highlighting
-            Node::CodeBlock { text, .. } => {
+            markdown::MarkdownNode::CodeBlock { text, .. } => {
                 let mut lines = MarkdownView::code_block(text);
                 lines.insert(0, Line::default());
                 lines
             }
             // TODO: Support callout block quote types
-            Node::BlockQuote { nodes, .. } => {
+            markdown::MarkdownNode::BlockQuote { nodes, .. } => {
                 let mut lines = nodes
                     .into_iter()
                     .flat_map(|child| {


### PR DESCRIPTION
[Fix breaking change and use MarkdownNode instead of Node](https://github.com/erikjuhani/basalt/commit/d86f7d788364475c4679c33c6cac6997858846e7)

The Node is now a generic Node that contains the MarkdownNode and
source_range.

Changelog: fix
Module: basalt-widgets
Scope: markdown