### PR TITLE
Improvements to `obsidian` module in `basalt-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "basalt-core"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "dirs",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["basalt-core", "basalt-widgets"]
 resolver = "2"
 
 [workspace.dependencies]
-basalt-core = { path = "basalt-core", version = "0.3.0" }
+basalt-core = { path = "basalt-core", version = "0.4.1" }

--- a/basalt-core/CHANGELOG.md
+++ b/basalt-core/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- [Change `TryInto` to `TryFrom`](https://github.com/erikjuhani/basalt/commit/d0cc15c14d21507b148499808e92da78d958c771)
+
+### Breaking
+
+- [Move `Default` impl of `Note` under `note.rs`](https://github.com/erikjuhani/basalt/commit/3916185bf946dc6ff8af3efee02526ae3175fff5)
+- [Return `Vec<&Vault>` from `vaults()` instead of `Iterator`](https://github.com/erikjuhani/basalt/commit/f7587c98e119bc0bb43b55425baeb2797d9682ee)
+- [Use `Path` instead `PathBuf` when loading config from path](https://github.com/erikjuhani/basalt/commit/256fb33d8b0cb893496a1eea8a08ce025f33fb48)
+- [Use `BTreeMap` instead of `HashMap` to keep same order of vaults](https://github.com/erikjuhani/basalt/commit/7ed11881cd83cc489f98bf0d2e679a6c7fa12d9d)
 - [Add `source_range` field to Nodes](https://github.com/erikjuhani/basalt/commit/1c199259f3831768e1823a34c9165c489f71eed0)
 
 ## 0.2.2 (2025-02-27)

--- a/basalt-core/Cargo.toml
+++ b/basalt-core/Cargo.toml
@@ -6,7 +6,7 @@ Provides the core functionality for Basalt TUI application
 readme = "README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.3.0"
+version = "0.4.1"
 edition = "2021"
 
 [dependencies]

--- a/basalt-core/src/obsidian.rs
+++ b/basalt-core/src/obsidian.rs
@@ -33,18 +33,12 @@ pub use vault::Vault;
 /// # Examples
 ///
 /// ```
-/// use basalt_core::obsidian::{ObsidianConfig, Result};
+/// use std::path::Path;
+/// use basalt_core::obsidian::{ObsidianConfig, Error};
 ///
-/// fn get_vault_names() -> Result<Vec<String>> {
-///     let config = ObsidianConfig::load()?;
-///     Ok(config.vaults().map(|(name,_)| name).collect())
-/// }
 ///
-/// fn main() -> Result<()> {
-///     let vaults = get_vault_names()?;
-///     println!("Found vaults: {:?}", vaults);
-///     Ok(())
-/// }
+/// let config_result = ObsidianConfig::load_from(Path::new("./nonexistent"));
+/// assert_eq!(config_result.is_err(), true);
 /// ```
 pub type Result<T> = result::Result<T, Error>;
 

--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -54,10 +54,13 @@ impl ObsidianConfig {
     ///     ("Work", Vault::default()),
     /// ]);
     ///
-    /// _ = config.vaults();
+    /// let vaults = config.vaults();
+    ///
+    /// assert_eq!(vaults.len(), 2);
+    /// assert_eq!(vaults.get(0), Some(&Vault::default()).as_ref());
     /// ```
-    pub fn vaults(&self) -> impl Iterator<Item = (String, Vault)> {
-        self.vaults.clone().into_iter()
+    pub fn vaults(&self) -> Vec<&Vault> {
+        self.vaults.values().collect()
     }
 
     /// Finds a vault by name, returning a reference if it exists.
@@ -175,7 +178,8 @@ impl<'de> Deserialize<'de> for ObsidianConfig {
             }
         }
 
-        Ok(Json::from(Deserialize::deserialize(deserializer)?).into())
+        let deserialized: Json = Deserialize::deserialize(deserializer)?;
+        Ok(deserialized.into())
     }
 }
 

--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -2,7 +2,7 @@ use dirs::config_local_dir;
 
 use serde::{Deserialize, Deserializer};
 use std::result;
-use std::{collections::HashMap, fs, path::PathBuf};
+use std::{collections::BTreeMap, fs, path::PathBuf};
 
 use crate::obsidian::{Error, Result, Vault};
 
@@ -10,7 +10,7 @@ use crate::obsidian::{Error, Result, Vault};
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ObsidianConfig {
     /// A mapping of vault (folder) names to [`Vault`] definitions.
-    vaults: HashMap<String, Vault>,
+    vaults: BTreeMap<String, Vault>,
 }
 
 impl ObsidianConfig {
@@ -122,7 +122,7 @@ impl<const N: usize> From<[(&str, Vault); N]> for ObsidianConfig {
     /// ```
     fn from(arr: [(&str, Vault); N]) -> Self {
         Self {
-            vaults: HashMap::from(arr.map(|(name, vault)| (name.to_owned(), vault))),
+            vaults: BTreeMap::from(arr.map(|(name, vault)| (name.to_owned(), vault))),
         }
     }
 }
@@ -147,7 +147,7 @@ impl<const N: usize> From<[(String, Vault); N]> for ObsidianConfig {
     /// ```
     fn from(arr: [(String, Vault); N]) -> Self {
         Self {
-            vaults: HashMap::from(arr),
+            vaults: BTreeMap::from(arr),
         }
     }
 }
@@ -159,7 +159,7 @@ impl<'de> Deserialize<'de> for ObsidianConfig {
     {
         #[derive(Deserialize)]
         struct Json {
-            vaults: HashMap<String, Vault>,
+            vaults: BTreeMap<String, Vault>,
         }
 
         impl From<Json> for ObsidianConfig {

--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -1,6 +1,7 @@
 use dirs::config_local_dir;
 
 use serde::{Deserialize, Deserializer};
+use std::path::Path;
 use std::result;
 use std::{collections::BTreeMap, fs, path::PathBuf};
 
@@ -19,12 +20,12 @@ impl ObsidianConfig {
     /// Returns an [`Error`] if the filepath doesn't exist or JSON parsing failed.
     pub fn load() -> Result<Self> {
         obsidian_config_dir()
-            .map(ObsidianConfig::load_from)
-            .ok_or_else(|| Error::PathNotFound("Obsidian config directory".to_string()))?
+            .map(|path_buf| ObsidianConfig::load_from(&path_buf))
+            .ok_or(Error::PathNotFound("Obsidian config directory".to_string()))?
     }
 
     /// Attempts to load `obsidian.json` file as an [`ObsidianConfig`] from the given directory
-    /// [`PathBuf`].
+    /// [`Path`].
     ///
     /// Returns an [`Error`] if the filepath doesn't exist or JSON parsing failed.
     ///
@@ -32,12 +33,12 @@ impl ObsidianConfig {
     ///
     /// ```
     /// use basalt_core::obsidian::ObsidianConfig;
-    /// use std::path::PathBuf;
+    /// use std::path::Path;
     ///
-    /// _ = ObsidianConfig::load_from(PathBuf::from("./dir-with-config-file"));
+    /// _ = ObsidianConfig::load_from(Path::new("./dir-with-config-file"));
     /// ```
-    pub fn load_from(dir: PathBuf) -> Result<Self> {
-        let contents = fs::read_to_string(dir.join("obsidian.json"))?;
+    pub fn load_from(config_path: &Path) -> Result<Self> {
+        let contents = fs::read_to_string(config_path.join("obsidian.json"))?;
         Ok(serde_json::from_str(&contents)?)
     }
 

--- a/basalt-core/src/obsidian/note.rs
+++ b/basalt-core/src/obsidian/note.rs
@@ -17,6 +17,16 @@ pub struct Note {
     pub created: SystemTime,
 }
 
+impl Default for Note {
+    fn default() -> Self {
+        Self {
+            name: String::default(),
+            path: PathBuf::default(),
+            created: SystemTime::UNIX_EPOCH,
+        }
+    }
+}
+
 impl Note {
     /// Reads the note's contents from disk to a `String`.
     ///

--- a/basalt-core/src/obsidian/vault.rs
+++ b/basalt-core/src/obsidian/vault.rs
@@ -88,10 +88,10 @@ impl<'de> Deserialize<'de> for Vault {
             ts: u64,
         }
 
-        impl TryInto<Vault> for Json {
+        impl TryFrom<Json> for Vault {
             type Error = String;
-            fn try_into(self) -> result::Result<Vault, Self::Error> {
-                let path = Path::new(&self.path);
+            fn try_from(value: Json) -> Result<Self, Self::Error> {
+                let path = Path::new(&value.path);
                 let name = path
                     .file_name()
                     .ok_or_else(|| String::from("unable to retrieve vault name"))?

--- a/basalt-core/src/obsidian/vault.rs
+++ b/basalt-core/src/obsidian/vault.rs
@@ -3,7 +3,6 @@ use std::{
     fs::{self, read_dir},
     path::{Path, PathBuf},
     result,
-    time::SystemTime,
 };
 
 use serde::{Deserialize, Deserializer};
@@ -100,26 +99,15 @@ impl<'de> Deserialize<'de> for Vault {
                     .to_string();
                 Ok(Vault {
                     name,
-                    path: self.path,
-                    open: self.open.unwrap_or_default(),
-                    ts: self.ts,
+                    path: value.path,
+                    open: value.open.unwrap_or_default(),
+                    ts: value.ts,
                 })
             }
         }
 
-        Json::from(Deserialize::deserialize(deserializer)?)
-            .try_into()
-            .map_err(serde::de::Error::custom)
-    }
-}
-
-impl Default for Note {
-    fn default() -> Self {
-        Self {
-            name: String::default(),
-            path: PathBuf::default(),
-            created: SystemTime::now(),
-        }
+        let deserialized: Json = Deserialize::deserialize(deserializer)?;
+        deserialized.try_into().map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
#### [Use BTreeMap instead of HashMap to keep same order of vaults](https://github.com/erikjuhani/basalt/commit/e3b18431e6cf449e350ad2733adaeec6a66646f5)
>HashMap does not retain order of the vaults. BTreeMap is an ordered map,
>so it retains the same order for the vaults.

#### [**Use Path instead PathBuf when loading config from path**](https://github.com/erikjuhani/basalt/commit/16793fd0bc274ded7477ce9c136e59c2bcc7482c)
>The function can take a reference and does not need to take the
>ownership of the value, which in my opinion will be more user friendly.
>
>Otherwise the function will force a move and users will have to clone
>the passed value if they wish to use it later in the body.

#### [Return Vec<&Vault> from vaults() instead of Iterator](https://github.com/erikjuhani/basalt/commit/4ff4800567939252f5a00542ff5742e5bd5b5979)
>Returning an iterator felt surprising and made the callers do more work
>than perhaps necessary. The intention usually is to capture the vector
>of all the vaults and not necessarily modify the values or call next
>separately. That can be achieved by turning the `Vec` into iterator
>instead, which to me is more idiomatic Rust anyway.

#### [Move Default impl of Note under note.rs](https://github.com/erikjuhani/basalt/commit/f28f0e59ea2d6ec7ceea413cce73d1585efc0835)
>By mistake the Default impl was defined under `vault.rs` and in this
>commit was changed to correct place. The default for `SystemTime` was
>changed from now to unix epoch, which makes this commit breaking.

#### [Change TryInto to TryFrom](https://github.com/erikjuhani/basalt/commit/cbe0ea4c3ef59b3f0ffc3252e804d02746d4f20c)
>`TryFrom` will also implement `try_into`.

#### [Update CHANGELOG for basalt-core and bump to version 0.4.1](https://github.com/erikjuhani/basalt/commit/a15b4b1b80c448971fab45e627709e1f4f598d20)