### PR TITLE
Basalt TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "basalt-core"
 version = "0.4.1"
 dependencies = [
@@ -17,7 +23,18 @@ dependencies = [
  "pulldown-cmark",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "basalt-tui"
+version = "0.3.0"
+dependencies = [
+ "basalt-core",
+ "basalt-widgets",
+ "crossterm",
+ "indoc",
+ "ratatui",
 ]
 
 [[package]]
@@ -30,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "cassowary"
@@ -70,10 +87,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.10"
+name = "crossterm"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -81,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -95,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -122,20 +164,30 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fnv"
@@ -145,9 +197,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getopts"
@@ -160,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -194,9 +246,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "instability"
@@ -222,15 +274,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libredox"
@@ -241,6 +293,28 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
@@ -258,10 +332,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "paste"
@@ -271,9 +380,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -299,9 +408,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -315,6 +424,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
+ "crossterm",
  "indoc",
  "instability",
  "itertools",
@@ -324,6 +434,15 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -338,31 +457,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.19"
+name = "rustix"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -371,15 +509,51 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "static_assertions"
@@ -417,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -437,11 +611,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -457,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,9 +648,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -514,12 +688,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -528,13 +742,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -544,10 +774,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -556,10 +798,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -568,13 +828,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
-members = ["basalt-core", "basalt-widgets"]
+members = ["basalt", "basalt-core", "basalt-widgets"]
 resolver = "2"
 
 [workspace.dependencies]
+basalt = { path = "basalt", version = "0.3.0" }
 basalt-core = { path = "basalt-core", version = "0.4.1" }
+basalt-widgets = { path = "basalt-widgets", version = "0.1.1" }

--- a/README.md
+++ b/README.md
@@ -8,11 +8,92 @@ TUI Application to manage Obsidian vaults and notes directly from the terminal �
 
 <img src="assets/basalt_demo.gif">
 
-## When is Basalt released?
+## Installation
 
-For the past month I've been working hard to build up the foundation of which will be the start of Basalt TUI. The features are visible in the demo gif.
+For now unfortunately, you have to compile this binary yourself, if you want to run basalt. The next thing I'll be doing is adding a GitHub workflow to produce cross-platform binaries.
 
-I am aiming to release the first version of basalt in 1-2 weeks from now, so before May 2025.
+## Background
 
-The first version will have a very limited set of features and will be
-susceptible to changes at any time. The major drawback will be the inability to modify any notes.
+This is something that has been brewing in my head for quite some time. There has been different incarnations over the years, however, nothing as substantial as this.
+
+I have been using Neovim and the official Obsidian app. However, I wanted to have something dedicated that offers the same writing experience as Neovim, but has more WYSIWYG experience as in the official Obsidian app. I'm fully aware of (obsidian.nvim)[https://github.com/epwalsh/obsidian.nvim], which many people use and find more than sufficient. However, I want to see images, beautified text, note graphs, etc. I want it to be a bit more.
+
+The problem for me personally is that when I leave the terminal, my flow breaks, especially if I'm writing. Using an entirely different app disrupts that flow, and it _annoys_ me. So here I am, building a TUI for Obsidian.
+
+The goal of basalt is not to replace the Obsidian app. Basalt is to fill and cater for a need to have a terminal view to the selection of notes and vaults, providing quick access from anywhere in the terminal with a simple command.
+
+## Keybindings
+
+For now these are not configurable, but this will change when the configuration file is supported.
+
+<kbd>q</kbd> Quit the application
+
+<kbd>?</kbd> Show help
+
+<kbd>t</kbd> Toggle side panel visibility and select mode
+
+<kbd>k</kbd> Move selection up
+
+<kbd>j</kbd> Move selection down
+
+<kbd>↑ / ↓</kbd> Scroll selected up / down
+
+<kbd>↩ Enter</kbd> Select the highlighted note
+
+<kbd>Space</kbd> Toggle vault selector modal
+
+<kbd>Ctrl-u</kbd> Scroll up half a page
+
+<kbd>Ctrl-d</kbd> Scroll down half a page
+
+## Task List
+
+- [x] Add rudimentary support for markdown rendering
+- [x] Add Sidepanel for note selection in vault
+- [x] Add bottom information bar that shows the current mode Select, Normal, Insert and statistics for words and characters
+- [x] Add help modal / popup with `?`
+- [x] Add vault selection screen with basalt logo (Splash screen)
+- [x] Add vault selector modal
+- [ ] GitHub Workflows !
+    - [ ] Run tests and build
+    - [ ] Run create release artifacts (cross-platform binaries)
+    - [ ] Run vhs when basalt dir changes and commit it to the current PR
+- [ ] Async file loading (tokio)
+- [ ] Persistent scroll state in help modal
+- [ ] Fuzzy search in panes (note, sidepanel, modals)
+- [ ] Markdown rendering
+    - [ ] Add support to all markdown nodes
+    - [ ] Add text formatting to different styles like Fraktur and DoubleStruck for heading purposes
+    - [ ] Improve and fix codeblock rendering so it appears as a 'block'
+    - [ ] Support complete Obsidian Flavor
+    - [ ] Add image rendering support
+- [ ] Note tree
+    - [ ] Create new note under vault
+    - [ ] Collapsible folders
+    - [ ] Notes within Folders in vault
+    - [ ] Move note
+    - [ ] Rename note
+    - [ ] Delete note under vault (with confirmation modal)
+- [ ] Editor mode
+    - [ ] Editor mode should change to raw text where cursor is. Only changes the current markdown node. Text is inserted node by node.
+    - [ ] Edit and save notes
+    - [ ] Support some vim keybindings to get started (vim mode should be configurable option)
+    - [ ] Easy text yanking
+- [ ] Command bar
+    - [ ] Add ability to invoke command bar with `:`
+    - [ ] Add commands for saving `:w` and quitting `:q`
+    - [ ] Switch between scrollbar and paging using a command `:set scroll` or `:set paging`. Paging will only fit the content it can within the height of the rect and generate pages accordingly.
+- [ ] Configuration file (.basalt.toml)
+    - [ ] Add rudimentary config file and move keybinds to the file
+- [ ] Wrap lines with prefix (calculate width and add length of prefix)
+- [ ] Easy backups with Git (Config, (git2-rs)[https://github.com/rust-lang/git2-rs])
+- [ ] Integration tests using https://core.tcl-lang.org/expect/index
+- [ ] When creating a link show autocomplete tooltip list of potential files to link to
+- [ ] Add features to basalt-core and basalt-widgets. Default feature set and individual features.
+- [ ] Clickable checkboxes
+
+## I want to help
+
+I haven't yet had the chance to add a contributors' guide. If you would like to help, please feel free to create a pull request directly. At this stage, opening a separate issue is not required unless you would like to start a discussion first.
+
+Please note that this process may change in the future. The expected contribution flow will likely become: Create issue → Create pull request.

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.3.0
+
+### Added
+
+- [Add `app` module](https://github.com/erikjuhani/basalt/commit/bd615f8da8813312fd9351b1ccdcf5e29b164d6d)
+- [Add `start` module](https://github.com/erikjuhani/basalt/commit/e5ce84bee9b3801fdc4aecd43eb091c3055050fd)
+- [Add `help_modal` module with `help.txt`](https://github.com/erikjuhani/basalt/commit/617e688bc277e4534d2f8fafaf9f0288cd026702)
+- [Add `statusbar` module](https://github.com/erikjuhani/basalt/commit/05b42183514172c1b640c0d7ae5d6e3683942d5f)
+- [Add `sidepanel` module](https://github.com/erikjuhani/basalt/commit/537917da8905db138c0839a05df2e80795f29524)
+- [Add `vault_selector` and `vault_selector_modal`](https://github.com/erikjuhani/basalt/commit/8a42a008c094088a5bfb76178d566fd71246d380)
+- [Add `text_counts` module](https://github.com/erikjuhani/basalt/commit/f646b8a1c2b0e055b7dd4c5b6f0963759200c731)

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "basalt-tui"
+description = """
+Basalt TUI application for Obsidian notes.
+"""
+readme = "README.md"
+repository = "https://github.com/erikjuhani/basalt"
+license = "MIT"
+version = "0.3.0"
+edition = "2021"
+
+[dependencies]
+basalt-core = { workspace = true }
+basalt-widgets = { workspace = true }
+ratatui = { version = "0.29.0", features = ["unstable-widget-ref"] }
+crossterm = "0.28.1"
+
+[dev-dependencies]
+indoc = "2"
+
+[[bin]]
+name = "basalt"
+path = "src/main.rs"
+
+[profile.dev]
+split-debuginfo = "unpacked"
+
+[profile.dev.build-override]
+opt-level = 3

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -1,0 +1,607 @@
+use basalt_core::obsidian::{Note, Vault};
+use basalt_widgets::markdown::{MarkdownView, MarkdownViewState};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect, Size},
+    widgets::{StatefulWidget, StatefulWidgetRef},
+    DefaultTerminal,
+};
+
+use std::{cell::RefCell, io::Result, marker::PhantomData};
+
+use crate::{
+    help_modal::{HelpModal, HelpModalState},
+    sidepanel::{SidePanel, SidePanelState},
+    start::{StartScreen, StartState},
+    statusbar::{StatusBar, StatusBarState},
+    text_counts::{CharCount, WordCount},
+    vault_selector_modal::{VaultSelectorModal, VaultSelectorModalState},
+};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const HELP_TEXT: &str = include_str!("./help.txt");
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum Mode {
+    #[default]
+    Select,
+    Normal,
+    Insert,
+}
+
+impl Mode {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Mode::Select => "Select",
+            Mode::Normal => "Normal",
+            Mode::Insert => "Insert",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum ScrollAmount {
+    #[default]
+    One,
+    HalfPage,
+}
+
+fn calc_scroll_amount(scroll_amount: ScrollAmount, size: Size) -> usize {
+    match scroll_amount {
+        ScrollAmount::One => 1,
+        ScrollAmount::HalfPage => (size.height / 3).into(),
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Action {
+    Select,
+    Next,
+    Prev,
+    Insert,
+    Resize(Size),
+    ScrollUp(ScrollAmount),
+    ScrollDown(ScrollAmount),
+    ToggleMode,
+    ToggleHelp,
+    ToggleVaultSelector,
+    Quit,
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Start<'a> {
+    pub start_state: StartState<'a>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Main<'a> {
+    pub sidepanel_state: SidePanelState<'a>,
+    pub selected_note: Option<SelectedNote>,
+    pub markdown_view_state: MarkdownViewState,
+    pub notes: Vec<Note>,
+    pub vaults: Vec<&'a Vault>,
+    pub size: Size,
+    pub mode: Mode,
+}
+
+impl<'a> Main<'a> {
+    fn new(vault_name: &'a str, notes: Vec<Note>, size: Size, vaults: Vec<&'a Vault>) -> Self {
+        Self {
+            notes: notes.clone(),
+            sidepanel_state: SidePanelState::new(vault_name, notes),
+            vaults,
+            size,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Screen<'a> {
+    Start(Start<'a>),
+    Main(Main<'a>),
+}
+
+impl Default for Screen<'_> {
+    fn default() -> Self {
+        Screen::Start(Start::default())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct AppState<'a> {
+    pub help_modal: Option<HelpModalState>,
+    pub vault_selector_modal: Option<VaultSelectorModalState<'a>>,
+    pub size: Size,
+    pub is_running: bool,
+    pub screen: Screen<'a>,
+    _lifetime: PhantomData<&'a ()>,
+}
+
+pub struct App<'a> {
+    pub state: AppState<'a>,
+    terminal: RefCell<DefaultTerminal>,
+}
+
+impl<'a> StatefulWidgetRef for App<'a> {
+    type State = AppState<'a>;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let screen = state.screen.clone();
+
+        match screen {
+            Screen::Start(mut state) => {
+                StartScreen::default().render_ref(area, buf, &mut state.start_state)
+            }
+            Screen::Main(mut state) => {
+                let [content, statusbar] =
+                    Layout::vertical([Constraint::Fill(1), Constraint::Length(1)])
+                        .horizontal_margin(1)
+                        .areas(area);
+
+                let (left, right) = if state.mode == Mode::Select {
+                    (Constraint::Length(35), Constraint::Fill(1))
+                } else {
+                    (Constraint::Length(5), Constraint::Fill(1))
+                };
+
+                let [sidepanel, note] = Layout::horizontal([left, right]).areas(content);
+
+                SidePanel::default().render_ref(sidepanel, buf, &mut state.sidepanel_state);
+
+                MarkdownView.render_ref(note, buf, &mut state.markdown_view_state);
+
+                let mode = state.mode.as_str().to_uppercase();
+                let (name, counts) = state
+                    .selected_note
+                    .clone()
+                    .map(|note| {
+                        let content = note.content.as_str();
+                        (
+                            note.name,
+                            (WordCount::from(content), CharCount::from(content)),
+                        )
+                    })
+                    .unzip();
+
+                let (word_count, char_count) = counts.unwrap_or_default();
+
+                let mut status_bar_state = StatusBarState::new(
+                    &mode,
+                    name.as_deref(),
+                    word_count.into(),
+                    char_count.into(),
+                );
+
+                StatusBar::default().render_ref(statusbar, buf, &mut status_bar_state);
+            }
+        }
+
+        if let Some(mut vault_selector_modal_state) = state.vault_selector_modal.clone() {
+            VaultSelectorModal::default().render(area, buf, &mut vault_selector_modal_state)
+        }
+
+        if let Some(mut help_modal_state) = state.help_modal.clone() {
+            HelpModal.render(area, buf, &mut help_modal_state)
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SelectedNote {
+    name: String,
+    path: String,
+    content: String,
+}
+
+impl From<&Note> for SelectedNote {
+    fn from(value: &Note) -> Self {
+        Self {
+            name: value.name.clone(),
+            path: value.path.to_string_lossy().to_string(),
+            content: Note::read_to_string(value).unwrap(),
+        }
+    }
+}
+
+fn help_text() -> String {
+    let version = format!("{VERSION}~alpha");
+    HELP_TEXT.replace(
+        "%version-notice",
+        format!("This is the read-only release of Basalt ({version})").as_str(),
+    )
+}
+
+impl<'a> App<'a> {
+    pub fn start(terminal: DefaultTerminal, vaults: Vec<&Vault>) -> Result<()> {
+        let version = format!("{VERSION}~alpha");
+        let size = terminal.size()?;
+
+        let state = AppState {
+            screen: Screen::Start(Start {
+                start_state: StartState::new(&version, size, vaults),
+            }),
+            size,
+            is_running: true,
+            _lifetime: PhantomData,
+            ..Default::default()
+        };
+
+        App {
+            state: state.clone(),
+            terminal: RefCell::new(terminal),
+        }
+        .run(state)
+    }
+
+    fn run(&mut self, state: AppState<'a>) -> Result<()> {
+        self.draw(&state)?;
+        let event = &event::read()?;
+        match self.update(&state, self.handle_event(event)) {
+            state if state.is_running => self.run(state),
+            _ => Ok(()),
+        }
+    }
+
+    fn update_help_modal(
+        &self,
+        state: AppState<'a>,
+        inner: HelpModalState,
+        action: Option<Action>,
+    ) -> AppState<'a> {
+        match action {
+            Some(Action::ScrollUp(amount)) => AppState {
+                help_modal: Some(inner.scroll_up(calc_scroll_amount(amount, state.size))),
+                ..state
+            },
+            Some(Action::ScrollDown(amount)) => AppState {
+                help_modal: Some(inner.scroll_down(calc_scroll_amount(amount, state.size))),
+                ..state
+            },
+            Some(Action::Next) => AppState {
+                help_modal: Some(inner.scroll_down(1)),
+                ..state
+            },
+            Some(Action::Prev) => AppState {
+                help_modal: Some(inner.scroll_up(1)),
+                ..state
+            },
+            _ => state,
+        }
+    }
+
+    fn update_vault_selector_modal(
+        &self,
+        state: AppState<'a>,
+        inner: VaultSelectorModalState<'a>,
+        action: Option<Action>,
+    ) -> AppState<'a> {
+        match action {
+            Some(Action::ToggleVaultSelector) => AppState {
+                vault_selector_modal: None,
+                ..state
+            },
+            Some(Action::Select) => {
+                // TODO: Add logic to not load the vault again if the same vault was picked in the
+                // selector.
+                let alphabetically =
+                    |a: &Note, b: &Note| a.name.to_lowercase().cmp(&b.name.to_lowercase());
+
+                let vault_selector_state = inner.vault_selector_state.select();
+
+                let vault_with_notes = vault_selector_state
+                    .selected()
+                    .and_then(|index| inner.vault_selector_state.get_item(index))
+                    .map(|vault| (vault, vault.notes_sorted_by(alphabetically)));
+
+                if let Some((vault, notes)) = vault_with_notes {
+                    AppState {
+                        screen: Screen::Main(Main::new(
+                            &vault.name,
+                            notes,
+                            state.size,
+                            vault_selector_state.items(),
+                        )),
+                        vault_selector_modal: None,
+                        ..state
+                    }
+                } else {
+                    state
+                }
+            }
+            Some(Action::Next) => AppState {
+                vault_selector_modal: Some(VaultSelectorModalState {
+                    vault_selector_state: inner.vault_selector_state.next(),
+                }),
+                ..state
+            },
+            Some(Action::Prev) => AppState {
+                vault_selector_modal: Some(VaultSelectorModalState {
+                    vault_selector_state: inner.vault_selector_state.previous(),
+                }),
+                ..state
+            },
+            _ => state,
+        }
+    }
+
+    fn update_select_mode(
+        &self,
+        state: AppState<'a>,
+        inner: Main<'a>,
+        action: Option<Action>,
+    ) -> AppState<'a> {
+        match action {
+            Some(Action::ToggleMode) => AppState {
+                screen: Screen::Main(Main {
+                    mode: Mode::Normal,
+                    sidepanel_state: inner.sidepanel_state.close(),
+                    ..inner
+                }),
+                ..state
+            },
+            Some(Action::ScrollUp(amount)) => AppState {
+                screen: Screen::Main(Main {
+                    markdown_view_state: inner
+                        .markdown_view_state
+                        .scroll_up(calc_scroll_amount(amount, state.size)),
+                    ..inner
+                }),
+                ..state
+            },
+            Some(Action::ScrollDown(amount)) => AppState {
+                screen: Screen::Main(Main {
+                    markdown_view_state: inner
+                        .markdown_view_state
+                        .scroll_down(calc_scroll_amount(amount, state.size)),
+                    ..inner
+                }),
+                ..state
+            },
+            Some(Action::Select) => {
+                let sidepanel_state = inner.sidepanel_state.select();
+
+                let selected_note = inner
+                    .notes
+                    .get(sidepanel_state.selected().unwrap_or_default())
+                    .map(SelectedNote::from);
+
+                AppState {
+                    screen: Screen::Main(Main {
+                        sidepanel_state,
+                        selected_note: selected_note.clone(),
+                        markdown_view_state: inner
+                            .markdown_view_state
+                            .set_text(selected_note.map(|note| note.content).unwrap_or_default())
+                            .reset_scrollbar(),
+                        ..inner
+                    }),
+                    ..state
+                }
+            }
+            Some(Action::Next) => AppState {
+                screen: Screen::Main(Main {
+                    sidepanel_state: inner.sidepanel_state.next(),
+                    ..inner
+                }),
+                ..state
+            },
+            Some(Action::Prev) => AppState {
+                screen: Screen::Main(Main {
+                    sidepanel_state: inner.sidepanel_state.previous(),
+                    ..inner
+                }),
+                ..state
+            },
+            _ => state,
+        }
+    }
+
+    fn update_normal_mode(
+        &self,
+        state: AppState<'a>,
+        inner: Main<'a>,
+        action: Option<Action>,
+    ) -> AppState<'a> {
+        let Some(action) = action else {
+            return state;
+        };
+
+        match action {
+            Action::ToggleMode => AppState {
+                screen: Screen::Main(Main {
+                    mode: Mode::Select,
+                    sidepanel_state: inner.sidepanel_state.open(),
+                    ..inner
+                }),
+                ..state
+            },
+            Action::ScrollUp(amount) => AppState {
+                screen: Screen::Main(Main {
+                    markdown_view_state: inner
+                        .markdown_view_state
+                        .scroll_up(calc_scroll_amount(amount, state.size)),
+                    ..inner
+                }),
+                ..state
+            },
+            Action::ScrollDown(amount) => AppState {
+                screen: Screen::Main(Main {
+                    markdown_view_state: inner
+                        .markdown_view_state
+                        .scroll_down(calc_scroll_amount(amount, state.size)),
+                    ..inner
+                }),
+                ..state
+            },
+            Action::Next => AppState {
+                screen: Screen::Main(Main {
+                    markdown_view_state: inner.markdown_view_state.scroll_down(1),
+                    ..inner
+                }),
+                ..state
+            },
+            Action::Prev => AppState {
+                screen: Screen::Main(Main {
+                    markdown_view_state: inner.markdown_view_state.scroll_up(1),
+                    ..inner
+                }),
+                ..state
+            },
+            _ => state,
+        }
+    }
+
+    fn update_main_state(
+        &self,
+        state: AppState<'a>,
+        inner: Main<'a>,
+        action: Option<Action>,
+    ) -> AppState<'a> {
+        if let Some(Action::ToggleVaultSelector) = action {
+            return AppState {
+                vault_selector_modal: if state.vault_selector_modal.is_some() {
+                    None
+                } else {
+                    Some(VaultSelectorModalState::new(inner.vaults.clone()))
+                },
+                ..state
+            };
+        }
+
+        match inner.mode {
+            Mode::Select => self.update_select_mode(state, inner, action),
+            Mode::Normal => self.update_normal_mode(state, inner, action),
+            Mode::Insert => state,
+        }
+    }
+
+    fn update_start_state(
+        &self,
+        state: AppState<'a>,
+        inner: Start<'a>,
+        action: Option<Action>,
+    ) -> AppState<'a> {
+        match action {
+            Some(Action::Select) => {
+                let alphabetically =
+                    |a: &Note, b: &Note| a.name.to_lowercase().cmp(&b.name.to_lowercase());
+
+                let splash_state = inner.start_state.select();
+
+                let vault_with_notes = splash_state
+                    .selected()
+                    .and_then(|index| splash_state.get_item(index))
+                    .map(|vault| (vault, vault.notes_sorted_by(alphabetically)));
+
+                if let Some((vault, notes)) = vault_with_notes {
+                    AppState {
+                        screen: Screen::Main(Main::new(
+                            &vault.name,
+                            notes,
+                            state.size,
+                            inner.start_state.items(),
+                        )),
+                        ..state
+                    }
+                } else {
+                    state
+                }
+            }
+            Some(Action::Next) => AppState {
+                screen: Screen::Start(Start {
+                    start_state: inner.start_state.next(),
+                }),
+                ..state
+            },
+            Some(Action::Prev) => AppState {
+                screen: Screen::Start(Start {
+                    start_state: inner.start_state.previous(),
+                }),
+                ..state
+            },
+            _ => state,
+        }
+    }
+
+    fn update(&self, state: &AppState<'a>, action: Option<Action>) -> AppState<'a> {
+        let state = state.clone();
+        let screen = state.screen.clone();
+        match action {
+            Some(Action::Quit) => AppState {
+                is_running: false,
+                ..state
+            },
+            Some(Action::ToggleHelp) => AppState {
+                help_modal: if state.help_modal.is_some() {
+                    None
+                } else {
+                    Some(HelpModalState::new(&help_text()))
+                },
+                ..state
+            },
+            Some(Action::Resize(size)) => AppState { size, ..state },
+            _ if state.help_modal.is_some() => {
+                self.update_help_modal(state.clone(), state.help_modal.unwrap().clone(), action)
+            }
+            _ if state.vault_selector_modal.is_some() => self.update_vault_selector_modal(
+                state.clone(),
+                state.vault_selector_modal.unwrap().clone(),
+                action,
+            ),
+            _ => match screen {
+                Screen::Start(inner) => self.update_start_state(state, inner, action),
+                Screen::Main(inner) => self.update_main_state(state, inner, action),
+            },
+        }
+    }
+
+    fn handle_event(&self, event: &Event) -> Option<Action> {
+        match event {
+            Event::Resize(cols, rows) => Some(Action::Resize(Size::new(*cols, *rows))),
+            Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
+                self.handle_press_key_event(key_event)
+            }
+            _ => None,
+        }
+    }
+
+    fn handle_press_key_event(&self, key_event: &KeyEvent) -> Option<Action> {
+        match key_event.code {
+            KeyCode::Char('q') => Some(Action::Quit),
+            KeyCode::Char('?') => Some(Action::ToggleHelp),
+            KeyCode::Char(' ') => Some(Action::ToggleVaultSelector),
+            KeyCode::Up => Some(Action::ScrollUp(ScrollAmount::One)),
+            KeyCode::Down => Some(Action::ScrollDown(ScrollAmount::One)),
+            KeyCode::Char('u') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(Action::ScrollUp(ScrollAmount::HalfPage))
+            }
+            KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(Action::Quit)
+            }
+            KeyCode::Char('d') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(Action::ScrollDown(ScrollAmount::HalfPage))
+            }
+            KeyCode::Char('t') => Some(Action::ToggleMode),
+            KeyCode::Char('k') => Some(Action::Prev),
+            KeyCode::Char('j') => Some(Action::Next),
+            KeyCode::Enter => Some(Action::Select),
+            _ => None,
+        }
+    }
+
+    fn draw(&self, state: &AppState<'a>) -> Result<()> {
+        let mut terminal = self.terminal.borrow_mut();
+        let mut state = state.clone();
+
+        terminal.draw(move |frame| {
+            let area = frame.area();
+            let buf = frame.buffer_mut();
+            self.render_ref(area, buf, &mut state);
+        })?;
+
+        Ok(())
+    }
+}

--- a/basalt/src/help.txt
+++ b/basalt/src/help.txt
@@ -1,0 +1,124 @@
+                                     ▒▓█▒░
+                                    ▒█▓▓░▒░
+                                   ██▓█▒▒▒▒
+                                  ▒▓██▓░▒▒▒░
+                                  ▓▒▒█▒▒░░░░
+                                   ░▒▒░░░▒░
+                                    ░▒▒▒▒░
+
+                                   ⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅
+
+                      TUI Application to manage Obsidian
+                 vaults and notes directly from the terminal.
+
+───────────────────────────────────────────────────────────────────────────────
+            %version-notice
+
+DISCLAIMER
+
+  Basalt is in its early stages, with a very limited set of features, and is
+  therefore susceptible to changes. Currently, the major drawback of Basalt is
+  the inability to modify any notes. Another limitation is the missing or
+  incomplete rendering of certain markdown styles. However, these features will
+  be prioritized in the next version.
+
+  Quitting the application may feel a bit abrupt, as the application exits
+  immediately after pressing ‹q›. I have some plans to handle this differently
+  in the future. For example, through a series of button presses or by using
+  command inputs similar to Vims ‹:quit› or ‹:q›.
+
+VAULT SELECTION
+
+  On startup screen you can select the Vault you want to view. Any vaults
+  considered open are shown with a ◆ symbol marker.
+
+      ‹q›         Quit the application
+      ‹?›         Show this help
+      ‹k›         Move selection up
+      ‹j›         Move selection down
+      ‹↩ Enter›   Select and open the highlighted vault
+
+  The vault selection can be brought up as a modal by hitting ‹Space› after
+  startup screen.
+
+MODES
+
+  The current mode is displayed in the bottom-left corner of the UI.
+
+  The distinction between the SELECT and NORMAL modes is that in SELECT mode,
+  you can browse and preview the notes in the vault, and in NORMAL mode, you
+  can navigate the content of a single selected note. Scrolling the notes work
+  in both modes.
+
+  SELECT
+          Navigate the vault's notes.
+
+          In SELECT mode, the vault contents can be selected by pressing Enter
+          or Return key. The list can be traversed up or down using ‹j› for
+          down and ‹k› for up. To change to NORMAL mode and hide the side
+          panel, press ‹t›.
+
+            ‹q›         Quit the application
+            ‹?›         Show this help
+            ‹t›         Toggle side panel visibility and select mode
+            ‹k›         Move selection up
+            ‹j›         Move selection down
+            ‹↑ / ↓›     Scroll selected note content up / down
+            ‹↩ Enter›   Select the highlighted note
+
+            ‹Space›     Toggle vault selector modal
+            ‹Ctrl-u›    Scroll selected note up half a page
+            ‹Ctrl-d›    Scroll selected note down half a page
+
+  NORMAL
+          Navigate the note.
+
+          In NORMAL mode, the contents of the note can be viewed and navigated.
+          Use mouse or arrow keys ‹↑ / ↓› to scroll up / down the note. To
+          toggle the SELECT mode and show side panel, press ‹t›.
+
+            ‹q›         Quit the application
+            ‹?›         Show this help
+            ‹t›         Toggle side panel visibility and select mode
+            ‹k›         Move selection up
+            ‹j›         Move selection down
+            ‹↑ / ↓›     Scroll selected note content up / down
+            ‹↩ Enter›   Select the highlighted note
+
+            ‹Space›     Toggle vault selector modal
+            ‹Ctrl-u›    Scroll selected note up half a page
+            ‹Ctrl-d›    Scroll selected note down half a page
+
+───────────────────────────────────────────────────────────────────────────────
+
+KEY BINDINGS
+
+  ‹q›         Quit the application
+  ‹?›         Show this help
+  ‹t›         Toggle side panel visibility and select mode
+  ‹k›         Move selection up
+  ‹j›         Move selection down
+  ‹↑ / ↓›     Scroll selected up / down
+  ‹↩ Enter›   Select the highlighted note
+
+  ‹Space›     Toggle vault selector modal
+  ‹Ctrl-u›    Scroll up half a page
+  ‹Ctrl-d›    Scroll down half a page
+
+───────────────────────────────────────────────────────────────────────────────
+
+FEATURES
+
+  • Navigate and open notes from the active Obsidian Vault.
+  • View markdown notes in a readable, custom styled format.
+
+───────────────────────────────────────────────────────────────────────────────
+
+KNOWN LIMITATIONS
+
+  • Images are not rendered.
+  • External links are not clickable.
+  • Nested folders are not supported.
+  • Notes cannot be modified.
+  • Key bindings cannot be changed with configuration.
+

--- a/basalt/src/help_modal.rs
+++ b/basalt/src/help_modal.rs
@@ -1,0 +1,109 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Flex, Layout, Rect},
+    style::{Color, Style, Stylize},
+    text::Line,
+    widgets::{
+        Block, BorderType, Clear, Padding, Paragraph, Scrollbar, ScrollbarOrientation,
+        ScrollbarState, StatefulWidget, Widget, Wrap,
+    },
+};
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct HelpModalState {
+    pub scrollbar_state: ScrollbarState,
+    pub scrollbar_position: usize,
+    pub viewport_height: usize,
+    pub text: String,
+}
+
+impl HelpModalState {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            scrollbar_state: ScrollbarState::new(text.lines().count()),
+            ..Default::default()
+        }
+    }
+
+    pub fn scroll_up(self, amount: usize) -> Self {
+        let scrollbar_position = self.scrollbar_position.saturating_sub(amount);
+        let scrollbar_state = self.scrollbar_state.position(scrollbar_position);
+
+        Self {
+            scrollbar_state,
+            scrollbar_position,
+            ..self
+        }
+    }
+
+    pub fn scroll_down(self, amount: usize) -> Self {
+        let scrollbar_position = self
+            .scrollbar_position
+            .saturating_add(amount)
+            .min(self.text.lines().count());
+
+        let scrollbar_state = self.scrollbar_state.position(scrollbar_position);
+
+        Self {
+            scrollbar_state,
+            scrollbar_position,
+            ..self
+        }
+    }
+
+    pub fn reset_scrollbar(self) -> Self {
+        Self {
+            scrollbar_state: ScrollbarState::default(),
+            scrollbar_position: 0,
+            ..self
+        }
+    }
+}
+
+fn modal_area(area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Percentage(50)]).flex(Flex::Center);
+    let horizontal = Layout::horizontal([Constraint::Length(83)]).flex(Flex::Center);
+    let [area] = vertical.areas(area);
+    let [area] = horizontal.areas(area);
+    area
+}
+
+pub struct HelpModal;
+
+impl StatefulWidget for HelpModal {
+    type State = HelpModalState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State)
+    where
+        Self: Sized,
+    {
+        let block = Block::bordered()
+            .black()
+            .border_type(BorderType::Rounded)
+            .padding(Padding::uniform(1))
+            .title_style(Style::default().italic().bold())
+            .title(" Help ")
+            .title(Line::from(" (?) ").alignment(Alignment::Right));
+
+        let area = modal_area(area);
+
+        Widget::render(Clear, area, buf);
+        Widget::render(
+            Paragraph::new(state.text.clone())
+                .wrap(Wrap::default())
+                .scroll((state.scrollbar_position as u16, 0))
+                .block(block)
+                .fg(Color::default()),
+            area,
+            buf,
+        );
+
+        StatefulWidget::render(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight),
+            area,
+            buf,
+            &mut state.scrollbar_state,
+        );
+    }
+}

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,5 +1,9 @@
 use std::io;
 
+use app::App;
+use basalt_core::obsidian::ObsidianConfig;
+
+pub mod app;
 pub mod help_modal;
 pub mod sidepanel;
 pub mod start;
@@ -9,5 +13,12 @@ pub mod vault_selector;
 pub mod vault_selector_modal;
 
 fn main() -> io::Result<()> {
+    let terminal = ratatui::init();
+    let obsidian_config = ObsidianConfig::load().unwrap();
+    let vaults = obsidian_config.vaults();
+
+    App::start(terminal, vaults)?;
+    ratatui::restore();
+
     Ok(())
 }

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,5 +1,7 @@
 use std::io;
 
+pub mod text_counts;
+
 fn main() -> io::Result<()> {
     Ok(())
 }

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,0 +1,5 @@
+use std::io;
+
+fn main() -> io::Result<()> {
+    Ok(())
+}

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,6 +1,8 @@
 use std::io;
 
 pub mod text_counts;
+pub mod vault_selector;
+pub mod vault_selector_modal;
 
 fn main() -> io::Result<()> {
     Ok(())

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+pub mod help_modal;
 pub mod sidepanel;
 pub mod statusbar;
 pub mod text_counts;

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -2,6 +2,7 @@ use std::io;
 
 pub mod help_modal;
 pub mod sidepanel;
+pub mod start;
 pub mod statusbar;
 pub mod text_counts;
 pub mod vault_selector;

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 pub mod sidepanel;
+pub mod statusbar;
 pub mod text_counts;
 pub mod vault_selector;
 pub mod vault_selector_modal;

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+pub mod sidepanel;
 pub mod text_counts;
 pub mod vault_selector;
 pub mod vault_selector_modal;

--- a/basalt/src/sidepanel.rs
+++ b/basalt/src/sidepanel.rs
@@ -1,0 +1,186 @@
+use std::marker::PhantomData;
+
+use basalt_core::obsidian::Note;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Style, Stylize},
+    text::Line,
+    widgets::{Block, BorderType, List, ListItem, ListState, StatefulWidgetRef},
+};
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SidePanelState<'a> {
+    pub(crate) title: &'a str,
+    pub(crate) selected_item_index: Option<usize>,
+    pub(crate) items: Vec<Note>,
+    pub(crate) open: bool,
+    list_state: ListState,
+}
+
+impl<'a> SidePanelState<'a> {
+    pub fn new(title: &'a str, items: Vec<Note>) -> Self {
+        SidePanelState {
+            items,
+            title,
+            selected_item_index: None,
+            list_state: ListState::default().with_selected(Some(0)),
+            open: true,
+        }
+    }
+
+    pub fn open(self) -> Self {
+        Self { open: true, ..self }
+    }
+
+    pub fn close(self) -> Self {
+        Self {
+            open: false,
+            ..self
+        }
+    }
+
+    pub fn toggle(self) -> Self {
+        Self {
+            open: !self.open,
+            ..self
+        }
+    }
+
+    fn calculate_offset(&self, window_height: usize) -> usize {
+        let half = window_height / 2;
+
+        let idx = self.list_state.selected().unwrap_or_default();
+
+        // When the selected item is near the end of the list and there aren't enough items
+        // remaining to keep the selection vertically centered, we shift the offset to show
+        // as many trailing items as possible instead of centering the selection.
+        //
+        // This prevents empty lines from appearing at the bottom of the list when the
+        // selection moves toward the end.
+        //
+        // Without this check, you'd see output like:
+        // ╭────────╮
+        // │ 3 item │
+        // │>4 item │
+        // │ 5 item │
+        // │        │
+        // ╰────────╯
+        //
+        // With this check, the list scrolls up to fill the remaining space:
+        // ╭────────╮
+        // │ 2 item │
+        // │ 3 item │
+        // │>4 item │
+        // │ 5 item │
+        // ╰────────╯
+        //
+        // The goal is to avoid showing unnecessary blank rows and to maximize visible items.
+        if idx + half > self.items.len() - 1 {
+            self.items.len().saturating_sub(window_height)
+        } else {
+            idx.saturating_sub(half)
+        }
+    }
+
+    pub fn update_offset_mut(&mut self, window_height: usize) -> &Self {
+        let offset = self.calculate_offset(window_height);
+
+        let list_state = &mut self.list_state;
+        *list_state.offset_mut() = offset;
+
+        self
+    }
+
+    pub fn select(&self) -> Self {
+        Self {
+            selected_item_index: self.list_state.selected(),
+            ..self.clone()
+        }
+    }
+
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_item_index
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub fn next(mut self) -> Self {
+        let index = self
+            .list_state
+            .selected()
+            .map(|i| (i + 1).min(self.items.len() - 1));
+
+        self.list_state.select(index);
+
+        Self {
+            list_state: self.list_state,
+            ..self
+        }
+    }
+
+    pub fn previous(mut self) -> Self {
+        self.list_state.select_previous();
+
+        Self {
+            list_state: self.list_state,
+            ..self
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct SidePanel<'a> {
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> StatefulWidgetRef for SidePanel<'a> {
+    type State = SidePanelState<'a>;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let block = Block::bordered()
+            .border_type(BorderType::Rounded)
+            .title_style(Style::default().italic().bold());
+
+        let items: Vec<ListItem> = state
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| match state.selected() {
+                Some(selected) if selected == i => ListItem::new(if state.open {
+                    format!("◆ {}", item.name)
+                } else {
+                    "◆".to_string()
+                }),
+                _ if state.open => ListItem::new(format!("  {}", item.name)),
+                _ => ListItem::new("◦"),
+            })
+            .collect();
+
+        let inner_area = block.inner(area);
+
+        state.update_offset_mut(inner_area.height.into());
+
+        if state.open {
+            List::new(items.to_vec())
+                .block(
+                    block
+                        .title(format!(" {} ", state.title))
+                        .title(Line::from(" ◀ ").alignment(Alignment::Right)),
+                )
+                .highlight_style(Style::new().reversed().dark_gray())
+                .highlight_symbol(" ")
+                .render_ref(area, buf, &mut state.list_state);
+        } else {
+            let layout = Layout::horizontal([Constraint::Length(5)]).split(area);
+
+            List::new(items)
+                .block(block.title(" ▶ "))
+                .highlight_style(Style::new().reversed().dark_gray())
+                .highlight_symbol(" ")
+                .render_ref(layout[0], buf, &mut state.list_state);
+        }
+    }
+}

--- a/basalt/src/start.rs
+++ b/basalt/src/start.rs
@@ -1,0 +1,157 @@
+use std::marker::PhantomData;
+
+use basalt_core::obsidian::Vault;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Flex, Layout, Rect, Size},
+    style::Stylize,
+    text::Text,
+    widgets::{StatefulWidgetRef, Widget},
+};
+
+use crate::vault_selector::{VaultSelector, VaultSelectorState};
+
+const TITLE: &str = "⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅";
+
+pub const LOGO: [&str; 25] = [
+    "           ▒███▓░          ",
+    "          ▒█████▒░         ",
+    "        ▒███▒██▓▒▒░        ",
+    "      ▒████░██▓▒░▒▒░       ",
+    "     ▒███▒▒██▒▒░ ░▒▒░      ",
+    "   ▒████▓▓██▒░▒░  ░▒▒▒░    ",
+    " ▒█████▓▓▓██ ░▒░  ░░▒▒▒░   ",
+    "░████▓▓▒░░██ ░░ ░░░░░░▒▒░  ",
+    "▒██▓▓▒░░░▒██░░▒░░░    ░▒░  ",
+    "░███▓░░░░██▓░░▒▒▒▒░   ░▒▒  ",
+    " ▒███░░░░██░░░░▒▒▒▒▒░░░▒▒  ",
+    " ▒▒██▒░░░██░░░░░░░▒▒▒░ ░▒  ",
+    " ▓▒░██░░▒█▓░░ ░░▒▒▒▒░ ░░▒  ",
+    " █▒▒██▒░▓█░░ ░▒▒▒▒▒▒░ ░░▒░ ",
+    "▒█▒▓▒██░██░▒▒▒▒▒░░░░ ░░░▒▒░",
+    "▓█▒▓▒▓██▓█░░░░░░░░░  ░ ░░▒▒",
+    "██▓▓▒▒▓█▓▓ ░░░░░░░░░░░░░░▒▒",
+    "▒█▓▒░░ ▒▒▒░░░░ ░▒░░ ░░░▒▒▒░",
+    "░▒▒▒░░░ ░░░░░░░░░░░░░░░▒▒░ ",
+    " ░░▒▒░ ░ ░░░░░░░░░░░░▒▒░   ",
+    "   ░▒▒▒░ ░ ░░░░░░░░▒▒░░    ",
+    "     ░▒▒░░  ░░░░░░▒▒░      ",
+    "       ░▒▒░░░░░▒▒▒▒░       ",
+    "        ░░▒▒▒▒▒▒▒░         ",
+    "          ░░▒▒░            ",
+];
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct StartState<'a> {
+    pub(crate) vault_selector_state: VaultSelectorState<'a>,
+    pub(crate) size: Size,
+    pub(crate) version: &'a str,
+}
+
+impl<'a> StartState<'a> {
+    pub fn new(version: &'a str, size: Size, items: Vec<&'a Vault>) -> Self {
+        let vault_selector_state = VaultSelectorState::new(items);
+
+        StartState {
+            version,
+            size,
+            vault_selector_state,
+        }
+    }
+
+    pub fn select(&self) -> Self {
+        Self {
+            vault_selector_state: self.vault_selector_state.select(),
+            ..self.clone()
+        }
+    }
+
+    pub fn items(self) -> Vec<&'a Vault> {
+        self.vault_selector_state.items
+    }
+
+    pub fn get_item(self, index: usize) -> Option<&'a Vault> {
+        self.vault_selector_state.items.get(index).cloned()
+    }
+
+    pub fn selected(&self) -> Option<usize> {
+        self.vault_selector_state.selected()
+    }
+
+    pub fn next(self) -> Self {
+        Self {
+            vault_selector_state: self.vault_selector_state.next(),
+            ..self
+        }
+    }
+
+    pub fn previous(self) -> Self {
+        Self {
+            vault_selector_state: self.vault_selector_state.previous(),
+            ..self
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct StartScreen<'a> {
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> StatefulWidgetRef for StartScreen<'a> {
+    type State = StartState<'a>;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let [_, center, _] = Layout::horizontal([
+            Constraint::Fill(1),
+            Constraint::Length(79),
+            Constraint::Fill(1),
+        ])
+        .areas(area);
+
+        let [_, top, bottom, _, help] = Layout::vertical([
+            Constraint::Fill(1),
+            Constraint::Length(28),
+            Constraint::Min(6),
+            Constraint::Fill(1),
+            Constraint::Length(1),
+        ])
+        .flex(Flex::Center)
+        .margin(1)
+        .areas(center);
+
+        let [logo, title] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(top);
+
+        let [_, title, version] = Layout::horizontal([
+            Constraint::Fill(1),
+            Constraint::Fill(1),
+            Constraint::Fill(1),
+        ])
+        .flex(Flex::SpaceBetween)
+        .margin(1)
+        .areas(title);
+
+        let [bottom] = Layout::horizontal([Constraint::Length(60)])
+            .flex(Flex::Center)
+            .areas(bottom);
+
+        Text::from_iter(LOGO).black().centered().render(logo, buf);
+
+        Text::from(TITLE).dark_gray().centered().render(title, buf);
+
+        Text::from(state.version)
+            .black()
+            .italic()
+            .centered()
+            .render(version, buf);
+
+        Text::from("Press (?) for help")
+            .italic()
+            .black()
+            .centered()
+            .render(help, buf);
+
+        VaultSelector::default().render_ref(bottom, buf, &mut state.vault_selector_state);
+    }
+}

--- a/basalt/src/statusbar.rs
+++ b/basalt/src/statusbar.rs
@@ -1,0 +1,88 @@
+use std::marker::PhantomData;
+
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Color, Stylize},
+    text::{Line, Span, Text},
+    widgets::{StatefulWidgetRef, Widget},
+};
+
+#[derive(Default, Clone, PartialEq)]
+pub struct StatusBarState<'a> {
+    mode: &'a str,
+    meta: Option<&'a str>,
+    word_count: usize,
+    char_count: usize,
+}
+
+impl<'a> StatusBarState<'a> {
+    pub fn new(mode: &'a str, meta: Option<&'a str>, word_count: usize, char_count: usize) -> Self {
+        Self {
+            mode,
+            meta,
+            word_count,
+            char_count,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct StatusBar<'a> {
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> StatefulWidgetRef for StatusBar<'a> {
+    type State = StatusBarState<'a>;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let [left, right] = Layout::horizontal([Constraint::Fill(1), Constraint::Length(28)])
+            .flex(Flex::SpaceBetween)
+            .areas(area);
+
+        let meta = state
+            .meta
+            .map(|meta| {
+                [
+                    Span::from(" ").bg(Color::Black),
+                    Span::from(meta).bg(Color::Black).gray().bold(),
+                    Span::from(" ").bg(Color::Black),
+                    Span::from("").black(),
+                ]
+            })
+            .unwrap_or_default();
+
+        Text::from(Line::from(
+            [
+                Span::from("").magenta(),
+                Span::from(" ").bg(Color::Magenta),
+                Span::from(state.mode).magenta().reversed().bold(),
+                Span::from(" ").bg(Color::Magenta),
+                Span::from("")
+                    .bg(if state.meta.is_some() {
+                        Color::Black
+                    } else {
+                        Color::default()
+                    })
+                    .magenta(),
+            ]
+            .into_iter()
+            .chain(meta)
+            .collect::<Vec<Span>>(),
+        ))
+        .render(left, buf);
+
+        let [word_count, char_count] =
+            Layout::horizontal([Constraint::Fill(1), Constraint::Fill(1)])
+                .flex(Flex::End)
+                .areas(right);
+
+        Text::from(format!("{} words", state.word_count))
+            .right_aligned()
+            .render(word_count, buf);
+
+        Text::from(format!("{} chars", state.char_count))
+            .right_aligned()
+            .render(char_count, buf);
+    }
+}

--- a/basalt/src/text_counts.rs
+++ b/basalt/src/text_counts.rs
@@ -1,0 +1,113 @@
+/// A wrapper type representing the number of characters in a string. **All** characters are
+/// counted for.
+///
+/// Character count can be created from an `usize` directly or computed from a `&str`.
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct CharCount(usize);
+
+impl From<usize> for CharCount {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for CharCount {
+    fn from(value: &str) -> Self {
+        value.chars().count().into()
+    }
+}
+
+impl From<CharCount> for usize {
+    fn from(value: CharCount) -> Self {
+        value.0
+    }
+}
+
+/// A wrapper type representing the number of words in a string.
+///
+/// Can be created from a `usize` directly or computed from a `&str` by counting the number of
+/// whitespace-separated words, after removing special markdown characters.
+///
+/// markdown characters: * _ ` < > ? ! [ ] ( ) = ~ # +
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct WordCount(usize);
+
+impl From<WordCount> for usize {
+    fn from(value: WordCount) -> Self {
+        value.0
+    }
+}
+
+impl From<usize> for WordCount {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for WordCount {
+    fn from(value: &str) -> Self {
+        let special_symbols = [
+            '*', '_', '`', '<', '>', '?', '!', '[', ']', '(', ')', '=', '~', '#', '+',
+        ];
+
+        value
+            .replace(special_symbols, "")
+            .split_whitespace()
+            .count()
+            .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn test_text_counts() {
+        let tests = [
+            (
+                indoc! {r#"# Heading 1
+
+                ## Heading 2
+
+                ### Heading 3
+
+                #### Heading 4
+
+                ##### Heading 5
+
+                ###### Heading 6"#},
+                (WordCount(12), CharCount(91)),
+            ),
+            (
+                indoc! { r#"## Tasks
+
+                - [ ] Task
+
+                - [x] Completed task
+
+                - [?] Completed task"#},
+                (WordCount(10), CharCount(64)),
+            ),
+            (
+                indoc! {r#"## Quotes
+
+                You _can_ quote text by adding a `>` symbols before the text.
+
+                > Human beings face ever more complex and urgent problems, and their effectiveness in dealing with these problems is a matter that is critical to the stability and continued progress of society.
+                >
+                >- Doug Engelbart, 1961"#},
+                (WordCount(47), CharCount(294)),
+            ),
+        ];
+
+        tests.into_iter().for_each(|(input, expected)| {
+            assert_eq!(
+                (WordCount::from(input), CharCount::from(input)),
+                expected,
+                "With input {input}"
+            )
+        });
+    }
+}

--- a/basalt/src/vault_selector.rs
+++ b/basalt/src/vault_selector.rs
@@ -1,0 +1,104 @@
+use std::marker::PhantomData;
+
+use basalt_core::obsidian::Vault;
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style, Stylize},
+    widgets::{Block, BorderType, List, ListItem, ListState, StatefulWidgetRef},
+};
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct VaultSelectorState<'a> {
+    pub(crate) selected_item_index: Option<usize>,
+    pub(crate) items: Vec<&'a Vault>,
+    list_state: ListState,
+}
+
+impl<'a> VaultSelectorState<'a> {
+    pub fn new(items: Vec<&'a Vault>) -> Self {
+        VaultSelectorState {
+            items,
+            selected_item_index: None,
+            list_state: ListState::default().with_selected(Some(0)),
+        }
+    }
+
+    pub fn select(&self) -> Self {
+        Self {
+            selected_item_index: self.list_state.selected(),
+            ..self.clone()
+        }
+    }
+
+    pub fn items(self) -> Vec<&'a Vault> {
+        self.items
+    }
+
+    pub fn get_item(self, index: usize) -> Option<&'a Vault> {
+        self.items.get(index).cloned()
+    }
+
+    pub fn selected(&self) -> Option<usize> {
+        self.selected_item_index
+    }
+
+    pub fn next(mut self) -> Self {
+        let index = self
+            .list_state
+            .selected()
+            .map(|i| (i + 1).min(self.items.len() - 1));
+
+        self.list_state.select(index);
+
+        Self {
+            list_state: self.list_state,
+            ..self
+        }
+    }
+
+    pub fn previous(mut self) -> Self {
+        self.list_state.select_previous();
+
+        Self {
+            list_state: self.list_state,
+            ..self
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct VaultSelector<'a> {
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> StatefulWidgetRef for VaultSelector<'a> {
+    type State = VaultSelectorState<'a>;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let items: Vec<ListItem> = state
+            .items
+            .iter()
+            .map(|item| {
+                if item.open {
+                    ListItem::new(format!("◆ {}", item.name))
+                } else {
+                    ListItem::new(format!("  {}", item.name))
+                }
+            })
+            .collect();
+
+        List::new(items)
+            .block(
+                Block::bordered()
+                    .black()
+                    .title(" Vaults ")
+                    .title_style(Style::default().italic().bold())
+                    .border_type(BorderType::Rounded),
+            )
+            .fg(Color::default())
+            .highlight_style(Style::new().reversed().dark_gray())
+            .highlight_symbol(" ")
+            .render_ref(area, buf, &mut state.list_state);
+    }
+}

--- a/basalt/src/vault_selector_modal.rs
+++ b/basalt/src/vault_selector_modal.rs
@@ -1,0 +1,121 @@
+use std::marker::PhantomData;
+
+use basalt_core::obsidian::Vault;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Flex, Layout, Rect},
+    widgets::{Clear, ScrollbarState, StatefulWidget, StatefulWidgetRef, Widget},
+};
+
+use crate::vault_selector::{VaultSelector, VaultSelectorState};
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct VaultSelectorModalState<'a> {
+    pub vault_selector_state: VaultSelectorState<'a>,
+}
+
+impl<'a> VaultSelectorModalState<'a> {
+    pub fn new(items: Vec<&'a Vault>) -> Self {
+        Self {
+            vault_selector_state: VaultSelectorState::new(items),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct VaultSelectorModal<'a> {
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl VaultSelectorModal<'_> {
+    fn modal_area(self, area: Rect) -> Rect {
+        let vertical = Layout::vertical([Constraint::Percentage(50)]).flex(Flex::Center);
+        let horizontal = Layout::horizontal([Constraint::Length(60)]).flex(Flex::Center);
+        let [area] = vertical.areas(area);
+        let [area] = horizontal.areas(area);
+        area
+    }
+}
+
+impl<'a> StatefulWidget for VaultSelectorModal<'a> {
+    type State = VaultSelectorModalState<'a>;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State)
+    where
+        Self: Sized,
+    {
+        let area = self.modal_area(area);
+        Widget::render(Clear, area, buf);
+        VaultSelector::default().render_ref(area, buf, &mut state.vault_selector_state);
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct ModalTitle<'a> {
+    pub left: &'a str,
+    pub right: Option<&'a str>,
+}
+
+impl<'a> ModalTitle<'a> {
+    pub fn new(title_left: &'a str, title_right: Option<&'a str>) -> Self {
+        Self {
+            left: title_left,
+            right: title_right,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct ModalState<'a> {
+    pub scrollbar_state: ScrollbarState,
+    pub scrollbar_position: usize,
+    pub viewport_height: usize,
+    pub text: &'a str,
+    pub title: ModalTitle<'a>,
+    pub is_open: bool,
+}
+
+impl<'a> ModalState<'a> {
+    pub fn new(title: ModalTitle<'a>, text: &'a str) -> Self {
+        Self {
+            title,
+            text,
+            scrollbar_state: ScrollbarState::new(text.lines().count()),
+            ..Default::default()
+        }
+    }
+
+    pub fn scroll_up(self, amount: usize) -> Self {
+        let scrollbar_position = self.scrollbar_position.saturating_sub(amount);
+        let scrollbar_state = self.scrollbar_state.position(scrollbar_position);
+
+        Self {
+            scrollbar_state,
+            scrollbar_position,
+            ..self
+        }
+    }
+
+    pub fn scroll_down(self, amount: usize) -> Self {
+        let scrollbar_position = self
+            .scrollbar_position
+            .saturating_add(amount)
+            .min(self.text.lines().count());
+
+        let scrollbar_state = self.scrollbar_state.position(scrollbar_position);
+
+        Self {
+            scrollbar_state,
+            scrollbar_position,
+            ..self
+        }
+    }
+
+    pub fn reset_scrollbar(self) -> Self {
+        Self {
+            scrollbar_state: ScrollbarState::default(),
+            scrollbar_position: 0,
+            ..self
+        }
+    }
+}

--- a/basalt_demo.tape
+++ b/basalt_demo.tape
@@ -1,0 +1,46 @@
+Output basalt.gif
+
+Set Padding 32
+Set FontSize 16
+Set Height 1000
+
+Set Theme "Whimsy"
+
+Type@100ms "basalt"
+Sleep 3s
+Enter
+Sleep 6s
+Type "j"
+Sleep 1s
+Type "j"
+Sleep 4s
+Enter
+Sleep 2s
+Type "j"
+Sleep 1s
+Type "j"
+Sleep 1.5s
+Enter
+Sleep 2s
+Type "t"
+Sleep 3s
+Ctrl+D
+Sleep 2s
+Ctrl+D
+Sleep 2s
+Ctrl+D
+Sleep 2s
+Ctrl+D
+Sleep 2s
+Ctrl+D
+Sleep 4s
+Type "?"
+Sleep 4s
+Ctrl+D
+Sleep 2s
+Ctrl+D
+Sleep 2s
+Ctrl+D
+Sleep 7s
+Type "q"
+Sleep 3s


### PR DESCRIPTION
#### [Add basalt workspace](https://github.com/erikjuhani/basalt/pull/8/commits/08a078295719c536a647223c87eaa95ad0e9b221)

> This workspace holds the source code for the basalt TUI application.

#### [Add vhs tape for basalt tui](https://github.com/erikjuhani/basalt/pull/8/commits/8ea4073ec7f67592482cf0f19e1aface6b363ddc)

> This `.tape` file can be used to record and output a `gif` that
> showcases Basalt TUI functionality. `vhs` is a separate CLI tool that
> enables generating videos out of the `.tape` files.

#### [Add text_counts module](https://github.com/erikjuhani/basalt/pull/8/commits/7826a4aae01e38639a026d3d81e19209ba4d814a)

> Text counts has two constructs `WordCount` and `CharCount`.
>
> WordCount is responsible for counting the words in the given `&str` it
> receives. CharCount on the other hand counts all the characters in the
> given `&str`.

#### [Add vault_selector and vault_selector_modal](https://github.com/erikjuhani/basalt/pull/8/commits/8a42a008c094088a5bfb76178d566fd71246d380)

> Vault selector is used to select a vault from a vec of given vaults.
>
> Internally uses the ratatui List widget and ListState struct to manage
> the list operations.
>
> Vaults that are marked open by Obsidian are shown with a symbol ◆
> marking that it is considered 'opened'.
>
> Vault selector modal is used when a vault is already loaded and the user
> wants to change the vault. Modal can be opened on top of existing screen
> and contains the vault selector within that enables changing the current
> vault.

#### [Add sidepanel module](https://github.com/erikjuhani/basalt/pull/8/commits/537917da8905db138c0839a05df2e80795f29524)

> Sidepanel is used to navigate the notes within a vault.
> 
> It uses the ratatui List widget and ListState struct to manage and
> operate the list state.
> 
> There is a custom selection index and that selection index will
> indicate, which note is considered currently open. The currently open
> note is displayed with a ◆ symbol.
> 
> Additionally the Sidepanel can be toggled, which will reduce the size of
> the panel to 5 and indicate that the sidepanel is 'closed' and 'freeing'
> more space for content. However the layout size change needs to be also
> handled in the caller side.

#### [Add statusbar module](https://github.com/erikjuhani/basalt/pull/8/commits/05b42183514172c1b640c0d7ae5d6e3683942d5f)

> The statusbar displays different modes of the application and other
> meta information e.g. the name of the currently opened note.
> 
> The statusbar also shows word and char count. This feature is intended
> to be used in conjuction with the `text_counts` module.

#### [Add help_modal module with help.txt](https://github.com/erikjuhani/basalt/pull/8/commits/617e688bc277e4534d2f8fafaf9f0288cd026702)

> The help modal is used to display help at any point in the application.
> 
> Help modal takes text as the only constructor parameter and will
> display it in a scrollable modal.
> 
> The `help.txt` contains all the key-bindings and other useful
> information for the user.

#### [Add start module](https://github.com/erikjuhani/basalt/pull/8/commits/e5ce84bee9b3801fdc4aecd43eb091c3055050fd)

> Start module is the start screen for basalt-tui, which displays the
> basalt logo in ASCII and vault selector for selecting a vault.

#### [Add app module](https://github.com/erikjuhani/basalt/pull/8/commits/bd615f8da8813312fd9351b1ccdcf5e29b164d6d)

> App module is the main basalt app. The app holds the complete state of
> the application and is built with ELM architecture, which means that the
> view and the state management is separated. The state updates are
> controlled by events called actions and are listed in the `Action` enum.
> 
> The basalt app has two screens Start and Main.
> 
> The start screen displays the application 'Splash' screen and the Main
> screen as the name states is the screen with the main functionality of
> the app like note selection and viewing.
> 
> The keybindings are also setup in the app module inside the
> `handle_press_key_event` function.

#### [Update root README](https://github.com/erikjuhani/basalt/pull/8/commits/f44c822d20a93ab4bf6f7892fad2dd0adbf63043)

> Add sections for installation, background, task list and 'I want to
> help'.