### PR TITLE
Adjusted the linux config location

### DIFF
--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -188,14 +188,14 @@ impl<'de> Deserialize<'de> for ObsidianConfig {
 /// For reference:
 /// - macOS:  `/Users/username/Library/Application Support/obsidian`
 /// - Windows: `%APPDATA%\Obsidian\`
-/// - Linux:   `$XDG_CONFIG_HOME/Obsidian/` or `~/.config/Obsidian/`
+/// - Linux:   `$XDG_CONFIG_HOME/obsidian/` or `~/.config/obsidian/`
 ///
 /// More info: [https://help.obsidian.md/Files+and+folders/How+Obsidian+stores+data]
 fn obsidian_config_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     const OBSIDIAN_CONFIG_DIR_NAME: &str = "obsidian";
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(target_os = "windows")]
     const OBSIDIAN_CONFIG_DIR_NAME: &str = "Obsidian";
 
     config_local_dir().map(|config_path| config_path.join(OBSIDIAN_CONFIG_DIR_NAME))


### PR DESCRIPTION
Congratulations on the first tui app release! I'm always excited to see progress on this project.

I've adjusted the conditional config location for linux from ~/.../Obsidian to ~/.../obsidian, following the information provided by the link in the original source. This fixed a "'Result::unwrap()' on an 'Err' value" runtime panic on my Linux machine.

Let me know if I've done this wrong or if this is inaccurate! My source for the correction is https://help.obsidian.md/data-storage#Global+settings.