### PR TITLE
Update CHANGELOG and bump basalt-core to 0.4.2

### DIFF
--- a/basalt-core/CHANGELOG.md
+++ b/basalt-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.2 (2025-05-01)
+
+### Fixed
+
+- [Adjusted the conditional config location for linux from ~/.../Obsidian to ~/.../obsidian, following the information provided by the link in the original source.](https://github.com/erikjuhani/basalt/commit/1bcc0375b9cb101e3fe8ace979c055ab0206bbd1)
+
 ## 0.4.1 (2025-04-20)
 
 ### Changed

--- a/basalt-core/Cargo.toml
+++ b/basalt-core/Cargo.toml
@@ -6,7 +6,7 @@ Provides the core functionality for Basalt TUI application
 readme = "README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
The patch version introduces a fix 1bcc037 for linux Obsidian config path name location. Previously this was falsely pointing to Obsidian instead of lowercased obsidian.