### PR TITLE
Add GitHub workflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Check
+      run: cargo check --profile ci
+
+    - name: Clippy
+      # Add the following after fixing clippy warnings: "-- -D warnings"
+      # This will ensure that no additional warnings are merged into 'main'
+      run: cargo clippy --profile ci --workspace --all-targets
+
+    - name: Test
+      run: cargo test --profile ci --workspace --all-targets
+
+    - name: Build
+      run: cargo build --profile ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ resolver = "2"
 basalt = { path = "basalt", version = "0.3.1" }
 basalt-core = { path = "basalt-core", version = "0.4.2" }
 basalt-widgets = { path = "basalt-widgets", version = "0.1.1" }
+
+[profile.ci]
+inherits = "dev"
+opt-level = 0

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -3,7 +3,7 @@ name = "basalt-tui"
 description = """
 Basalt TUI application for Obsidian notes.
 """
-readme = "README.md"
+readme = "../README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
 version = "0.3.1"


### PR DESCRIPTION
#### [Point to root README in basalt package](https://github.com/erikjuhani/basalt/commit/4ec70323c91719f26656aed97774e5926167c104)

> Otherwise, this produces an error when publishing the 'basalt-tui' app to crates.

#### [Add custom cargo profile ci](https://github.com/erikjuhani/basalt/commit/06debbacec8938c1d22874158b98cf80b9f70b1d)

> The custom profile uses no optimizations as we want to have fast runs for check, test and build.

#### [Add initial test workflow](https://github.com/erikjuhani/basalt/commit/8238556f437633354b427c50731d0164148b4cd1)

> The test workflow runs for every push, pull-request and can also be invoked manually.