### PR TITLE
Fix upload step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,11 @@ jobs:
       - name: Upload artifact and checksum to existing GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           ref_name="${{ github.ref_name }}"
-          version="${ref_name##*/}"
 
           artifact="${{ env.ARCHIVE }}"
           artifact_sum="${{ env.ARTIFACT_SUM }}"
-          gh release upload "${version}" "${artifact}" "${artifact_sum}"
+          gh release upload "${ref_name}" "${artifact}" "${artifact_sum}"
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ For now these are not configurable, but this will change when the configuration 
 - [ ] GitHub Workflows !
     - [x] Run tests and build
     - [x] Run create release artifacts (cross-platform binaries)
+    - [ ] Do not run test when pushing a tag
     - [ ] Run vhs when basalt dir changes and commit it to the current PR
 - [ ] Add mdbook and gh pages
 - [ ] Async file loading (tokio)


### PR DESCRIPTION
Should use the complete ref name instead of just the semantic version. In this case `basalt/v.*`, otherwise the upload command won't find any releases and fails the workflow.

Use bash shell in the upload step.