### PR TITLE
Allow content writing in permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This will allow the artifact upload to work. Without this the artifact upload will fail with HTTP 403: Resource not accessible by integration