### PR TITLE
Fix failing Linux builds with aarch64 and armv7 targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "rust-lld"
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+
       - name: Cache
         uses: actions/cache@v4
         with:
@@ -51,11 +54,15 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build
-        run: cargo build --profile release
-
-      - name: Add Rust target
-        run: rustup target add ${{ matrix.target }}
+      - name: Install linux build tools
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf \
+                                  libc6-dev-armhf-cross \
+                                  gcc-aarch64-linux-gnu \
+                                  musl-tools
 
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The cross compilation failed due to cargo calling the host linker, which produced errors such as:

```
error: linking with `cc` failed: exit status: 1
```

```
/usr/bin/ld: /home/runner/work/basalt/basalt/target/armv7-unknown-linux-gnueabihf/release/deps/basalt-68cb636f749dc709.basalt.1a71d1a4a2ff0e84-cgu.00.rcgu.o: relocations in generic ELF (EM: 40)
```

```
/usr/bin/ld: /home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crt1.o: Relocations in generic ELF (EM: 183)
```

These issues were fixed by providing correct linker to each affected target in `.cargo/config.toml` file.