### PR TITLE
Persitent help modal state: adds the hidden field to HelpModalState

### DIFF
--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -184,7 +184,9 @@ impl<'a> StatefulWidgetRef for App<'a> {
         }
 
         if let Some(mut help_modal_state) = state.help_modal.clone() {
-            HelpModal.render(area, buf, &mut help_modal_state)
+            if !help_modal_state.hidden {
+                HelpModal.render(area, buf, &mut help_modal_state)
+            }
         }
     }
 }
@@ -535,11 +537,14 @@ impl<'a> App<'a> {
                 ..state
             },
             Some(Action::ToggleHelp) => AppState {
-                help_modal: if state.help_modal.is_some() {
-                    None
-                } else {
-                    Some(HelpModalState::new(&help_text()))
-                },
+                help_modal: state
+                    .help_modal
+                    .map(|mut help_modal| {
+                        help_modal.hidden = !help_modal.hidden;
+
+                        help_modal
+                    })
+                    .or_else(|| Some(HelpModalState::new(&help_text()))),
                 ..state
             },
             Some(Action::Resize(size)) => AppState { size, ..state },

--- a/basalt/src/help_modal.rs
+++ b/basalt/src/help_modal.rs
@@ -15,6 +15,7 @@ pub struct HelpModalState {
     pub scrollbar_position: usize,
     pub viewport_height: usize,
     pub text: String,
+    pub hidden: bool,
 }
 
 impl HelpModalState {


### PR DESCRIPTION
Checks before rendering if the modal should stay 'hidden' or not.
On key press, checks if the modal has been initialized.
If that is indeed the case, change the 'hidden' flag from false to true, and vice versa.