### PR TITLE
Drop `v` version prefix from release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: |
           ref_name="${{ github.ref_name }}"
-          version="${ref_name##*/}"
+          version="${ref_name##*/v}"
 
           target="${{ matrix.target }}"
           bin_path="target/${target}/release"


### PR DESCRIPTION
Keeping the 'v' prefix is unnecessary and a good deal of other rust based projects do not release the artifacts with the 'v' prefix.