### PR TITLE
Refactor Markdown event parser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Clippy
       # Add the following after fixing clippy warnings: "-- -D warnings"
       # This will ensure that no additional warnings are merged into 'main'
-      run: cargo clippy --profile ci --workspace --all-targets
+      run: cargo clippy --profile ci --workspace --all-targets -- -D warnings
 
     - name: Test
       run: cargo test --profile ci --workspace --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ version = "0.4.2"
 dependencies = [
  "dirs",
  "indoc",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -34,6 +34,7 @@ dependencies = [
  "basalt-widgets",
  "crossterm",
  "indoc",
+ "pulldown-cmark 0.13.0",
  "ratatui",
 ]
 
@@ -392,6 +393,19 @@ name = "pulldown-cmark"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
  "bitflags",
  "getopts",

--- a/basalt-core/CHANGELOG.md
+++ b/basalt-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- [Fix clippy error with matches! expression](https://github.com/erikjuhani/basalt/commit/725eac3c0b5103a6de34cd155611d22091a245ab)
+
 ## 0.4.2 (2025-05-01)
 
 ### Fixed

--- a/basalt-core/src/markdown.rs
+++ b/basalt-core/src/markdown.rs
@@ -343,14 +343,14 @@ pub enum MarkdownNode {
 
 /// Returns `true` if the [`MarkdownNode`] should be closed upon encountering the given [`TagEnd`].
 fn matches_tag_end(node: &Node, tag_end: &TagEnd) -> bool {
-    match (&node.markdown_node, tag_end) {
+    matches!(
+        (&node.markdown_node, tag_end),
         (MarkdownNode::Paragraph { .. }, TagEnd::Paragraph)
-        | (MarkdownNode::Heading { .. }, TagEnd::Heading(..))
-        | (MarkdownNode::BlockQuote { .. }, TagEnd::BlockQuote(..))
-        | (MarkdownNode::CodeBlock { .. }, TagEnd::CodeBlock)
-        | (MarkdownNode::Item { .. }, TagEnd::Item) => true,
-        _ => false,
-    }
+            | (MarkdownNode::Heading { .. }, TagEnd::Heading(..))
+            | (MarkdownNode::BlockQuote { .. }, TagEnd::BlockQuote(..))
+            | (MarkdownNode::CodeBlock { .. }, TagEnd::CodeBlock)
+            | (MarkdownNode::Item { .. }, TagEnd::Item)
+    )
 }
 
 /// Parses the given Markdown input into a list of [`Node`]s.

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- [Refactor markdown event parsing](https://github.com/erikjuhani/basalt/commit/7115dfa48368f55a12e3a359c1941026ab203933)
+
 ## 0.3.1
 
 ### Fixed

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -14,6 +14,7 @@ basalt-core = { workspace = true }
 basalt-widgets = { workspace = true }
 ratatui = { version = "0.29.0", features = ["unstable-widget-ref"] }
 crossterm = "0.28.1"
+pulldown-cmark = "0.13.0"
 
 [dev-dependencies]
 indoc = "2"

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -1,5 +1,5 @@
+use super::markdown::{MarkdownView, MarkdownViewState};
 use basalt_core::obsidian::{Note, Vault};
-use basalt_widgets::markdown::{MarkdownView, MarkdownViewState};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::{
     buffer::Buffer,

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -5,6 +5,7 @@ use basalt_core::obsidian::ObsidianConfig;
 
 pub mod app;
 pub mod help_modal;
+pub mod markdown;
 pub mod sidepanel;
 pub mod start;
 pub mod statusbar;

--- a/basalt/src/markdown.rs
+++ b/basalt/src/markdown.rs
@@ -1,0 +1,20 @@
+mod state;
+mod view;
+
+/// Provides Markdown parser that supports Obsidian flavor.
+/// Obsidian flavor is a combination of different flavors and a few differences.
+///
+/// Namely `CommonMark` and `GitHub Flavored Markdown`. More info
+/// [here](https://help.obsidian.md/Editing+and+formatting/Obsidian+Flavored+Markdown).
+///
+/// NOTE: Current iteration does not handle Obsidian flavor, unless it is covered by
+/// pulldown-cmark. Part of Obsidian flavor is for example use of any character inside tasks to
+/// mark them as completed `- [?] Completed`.
+///
+/// This crate uses [`pulldown_cmark`] to parse the markdown and enable the applicable features. This
+/// crate uses own intermediate types to provide the parsed markdown nodes.
+/// pub mod markdown;
+mod parser;
+
+pub use state::MarkdownViewState;
+pub use view::MarkdownView;

--- a/basalt/src/markdown/parser.rs
+++ b/basalt/src/markdown/parser.rs
@@ -1,0 +1,791 @@
+//! A Markdown parser that transforms Markdown input into a custom abstract syntax tree (AST)
+//! intented to be rendered with [basalt](https://github.com/erikjuhani/basalt)—a TUI application
+//! for Obsidian.
+//!
+//! This module provides a [`Parser`] type, which processes raw Markdown input into a [`Vec`] of
+//! [`Node`]s. These [`Node`]s represent semantic elements such as headings, paragraphs, block
+//! quotes, and code blocks.
+//!
+//! The parser is built on top of [`pulldown_cmark`].
+//!
+//! ## Simple usage
+//!
+//! At the simplest level, you can parse a Markdown string by calling the [`from_str`] function:
+//!
+//! ```
+//! use basalt_core::markdown::{from_str, Range, Node, MarkdownNode, HeadingLevel, Text};
+//!
+//! let markdown = "# My Heading\n\nSome text.";
+//! let nodes = from_str(markdown);
+//!
+//! assert_eq!(nodes, vec![
+//!   Node {
+//!     markdown_node: MarkdownNode::Heading {
+//!       level: HeadingLevel::H1,
+//!       text: Text::from("My Heading"),
+//!     },
+//!     source_range: Range { start: 0, end: 13 },
+//!   },
+//!   Node {
+//!     markdown_node: MarkdownNode::Paragraph {
+//!       text: Text::from("Some text."),
+//!     },
+//!     source_range: Range { start: 14, end: 24 }
+//!   },
+//! ])
+//! ```
+//!
+//! ## Implementation details
+//!
+//! The [`Parser`] processes [`pulldown_cmark::Event`]s one by one, building up the current
+//! [`Node`] in `current_node`. When an event indicates the start of a new structure (e.g.,
+//! `Event::Start(Tag::Heading {..})`), the [`Parser`] pushes or replaces the current node
+//! with a new one. When an event indicates the end of that structure, the node is finalized
+//! and pushed into [`Parser::output`].
+//!
+//! Unrecognized events (such as [`InlineHtml`](pulldown_cmark::Event::InlineHtml)) are simply
+//! ignored for the time being.
+//!
+//! ## Not yet implemented
+//!
+//! - Handling of inline HTML, math blocks, etc.
+//! - Tracking code block language (`lang`) properly (currently set to [`None`]).
+use std::{iter::Peekable, vec::IntoIter};
+
+use pulldown_cmark::{Event, Options, Tag, TagEnd};
+
+/// A style that can be applied to [`TextNode`] (code, emphasis, strikethrough, strong).
+#[derive(Clone, Debug, PartialEq)]
+pub enum Style {
+    /// Inline code style (e.g. `code`).
+    Code,
+    // TODO: Additional style variants
+    //
+    // Italic/emphasis style (e.g. `*emphasis*` or `_emphasis_`).
+    // Emphasis,
+    // Strikethrough style (e.g. `~~strikethrough~~`).
+    // Strikethrough,
+    // Bold/strong style (e.g. `**strong**`).
+    // Strong,
+}
+
+/// Represents the variant of a list or task item (checked, unchecked, etc.).
+#[derive(Clone, Debug, PartialEq)]
+pub enum ItemKind {
+    // TODO: Ordered list
+    //
+    // An ordered list item (e.g., `1. item`), storing the numeric index.
+    // Ordered(u64),
+    /// An unordered list item (e.g., `- item`).
+    Unordered,
+}
+
+/// Represents the variant of a list or task item (checked, unchecked, etc.).
+#[derive(Clone, Debug, PartialEq)]
+pub enum TaskListItemKind {
+    /// A checkbox item that is marked as done using `- [x]`.
+    Checked,
+    /// A checkbox item that is unchecked using `- [ ]`.
+    Unchecked,
+    // TODO: Loose check
+    //
+    // A checkbox item that is checked, but not explicitly recognized as
+    // `Checked` (e.g., `- [?]`).
+    // LooselyChecked,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum HeadingLevel {
+    H1 = 1,
+    H2,
+    H3,
+    H4,
+    H5,
+    H6,
+}
+
+impl From<pulldown_cmark::HeadingLevel> for HeadingLevel {
+    fn from(value: pulldown_cmark::HeadingLevel) -> Self {
+        match value {
+            pulldown_cmark::HeadingLevel::H1 => HeadingLevel::H1,
+            pulldown_cmark::HeadingLevel::H2 => HeadingLevel::H2,
+            pulldown_cmark::HeadingLevel::H3 => HeadingLevel::H3,
+            pulldown_cmark::HeadingLevel::H4 => HeadingLevel::H4,
+            pulldown_cmark::HeadingLevel::H5 => HeadingLevel::H5,
+            pulldown_cmark::HeadingLevel::H6 => HeadingLevel::H6,
+        }
+    }
+}
+
+/// Represents specialized block quote kind variants (tip, note, warning, etc.).
+///
+/// Currently, the underlying [`pulldown_cmark`] parser distinguishes these via syntax like `">
+/// [!NOTE] Some note"`.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum BlockQuoteKind {
+    Note,
+    Tip,
+    Important,
+    Warning,
+    Caution,
+}
+
+impl From<pulldown_cmark::BlockQuoteKind> for BlockQuoteKind {
+    fn from(value: pulldown_cmark::BlockQuoteKind) -> Self {
+        match value {
+            pulldown_cmark::BlockQuoteKind::Tip => BlockQuoteKind::Tip,
+            pulldown_cmark::BlockQuoteKind::Note => BlockQuoteKind::Note,
+            pulldown_cmark::BlockQuoteKind::Warning => BlockQuoteKind::Warning,
+            pulldown_cmark::BlockQuoteKind::Caution => BlockQuoteKind::Caution,
+            pulldown_cmark::BlockQuoteKind::Important => BlockQuoteKind::Important,
+        }
+    }
+}
+
+/// Denotes whether a list is ordered or unordered.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ListKind {
+    /// An ordered list item (e.g., `1. item`), storing the numeric index.
+    Ordered(u64),
+    /// An unordered list item (e.g., `- item`).
+    Unordered,
+}
+
+/// A single unit of text that is optionally styled (e.g., code).
+///
+/// [`TextNode`] can be any combination of sentence, words or characters.
+///
+/// Usually styled text will be contained in a single [`TextNode`] with the given [`Style`]
+/// property.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct TextNode {
+    /// The literal text content.
+    pub content: String,
+    /// Optional inline style of the text.
+    pub style: Option<Style>,
+}
+
+impl From<&str> for TextNode {
+    fn from(value: &str) -> Self {
+        value.to_string().into()
+    }
+}
+
+impl From<String> for TextNode {
+    fn from(value: String) -> Self {
+        Self {
+            content: value,
+            ..Default::default()
+        }
+    }
+}
+
+impl TextNode {
+    /// Creates a new [`TextNode`] from `content` and optional [`Style`].
+    pub fn new(content: String, style: Option<Style>) -> Self {
+        Self { content, style }
+    }
+}
+
+/// A wrapper type holding a list of [`TextNode`]s.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Text(Vec<TextNode>);
+
+impl From<&str> for Text {
+    fn from(value: &str) -> Self {
+        TextNode::from(value).into()
+    }
+}
+
+impl From<String> for Text {
+    fn from(value: String) -> Self {
+        TextNode::from(value).into()
+    }
+}
+
+impl From<TextNode> for Text {
+    fn from(value: TextNode) -> Self {
+        Self([value].to_vec())
+    }
+}
+
+impl From<Vec<TextNode>> for Text {
+    fn from(value: Vec<TextNode>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&[TextNode]> for Text {
+    fn from(value: &[TextNode]) -> Self {
+        Self(value.to_vec())
+    }
+}
+
+impl IntoIterator for Text {
+    type Item = TextNode;
+    type IntoIter = IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Text {
+    /// Appends a [`TextNode`] to the inner text list.
+    fn push(&mut self, node: TextNode) {
+        self.0.push(node);
+    }
+}
+
+/// A [`std::ops::Range`] type for depicting range in [`crate::markdown`].
+///
+/// # Examples
+///
+/// ```
+/// use basalt_core::markdown::{Node, MarkdownNode, Range, Text};
+///
+/// let node = Node {
+///   markdown_node: MarkdownNode::Paragraph {
+///     text: Text::default(),
+///   },
+///   source_range: Range::default(),
+/// };
+/// ```
+pub type Range<Idx> = std::ops::Range<Idx>;
+
+/// A node in the Markdown AST.
+///
+/// Each `Node` contains a [`MarkdownNode`] variant representing a specific kind of Markdown
+/// element (paragraph, heading, code block, etc.), along with a `source_range` indicating where in
+/// the source text this node occurs.
+///
+/// # Examples
+///
+/// ```
+/// use basalt_core::markdown::{Node, MarkdownNode, Range, Text};
+///
+/// let node = Node::new(
+///   MarkdownNode::Paragraph {
+///     text: Text::default(),
+///   },
+///   0..10,
+/// );
+///
+/// assert_eq!(node.markdown_node, MarkdownNode::Paragraph { text: Text::default() });
+/// assert_eq!(node.source_range, Range { start: 0, end: 10 });
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct Node {
+    /// The specific Markdown node represented by this node.
+    pub markdown_node: MarkdownNode,
+
+    /// The range in the original source text that this node covers.
+    pub source_range: Range<usize>,
+}
+
+impl Node {
+    /// Creates a new `Node` from the provided [`MarkdownNode`] and source range.
+    pub fn new(markdown_node: MarkdownNode, source_range: Range<usize>) -> Self {
+        Self {
+            markdown_node,
+            source_range,
+        }
+    }
+
+    /// Pushes a [`TextNode`] into the markdown node, if it contains a text buffer.
+    ///
+    /// If the markdown node is a [`MarkdownNode::BlockQuote`], the [`TextNode`] will be pushed
+    /// into the last child [`Node`], if any.
+    /// ```
+    pub(crate) fn push_text_node(&mut self, node: TextNode) {
+        match &mut self.markdown_node {
+            MarkdownNode::Paragraph { text, .. }
+            | MarkdownNode::Heading { text, .. }
+            | MarkdownNode::CodeBlock { text, .. }
+            | MarkdownNode::TaskListItem { text, .. }
+            | MarkdownNode::Item { text, .. } => text.push(node),
+            MarkdownNode::List { nodes, .. } | MarkdownNode::BlockQuote { nodes, .. } => {
+                if let Some(last_node) = nodes.last_mut() {
+                    last_node.push_text_node(node);
+                }
+            }
+        }
+    }
+}
+
+/// The Markdown AST node enumeration.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum MarkdownNode {
+    /// A heading node that represents different heading levels.
+    ///
+    /// The level is controlled with the [`HeadingLevel`] definition.
+    Heading {
+        level: HeadingLevel,
+        text: Text,
+    },
+
+    /// A paragraph
+    Paragraph {
+        text: Text,
+    },
+
+    /// A block quote node that represents different quote block variants including callout blocks.
+    ///
+    /// The variant is controlled with the [`BlockQuoteKind`] definition. When [`BlockQuoteKind`]
+    /// is [`None`] the block quote should be interpreted as a regular block quote:
+    /// `"> Block quote"`.
+    BlockQuote {
+        kind: Option<BlockQuoteKind>,
+        nodes: Vec<Node>,
+    },
+
+    /// A fenced code block, optionally with a language identifier.
+    CodeBlock {
+        lang: Option<String>,
+        text: Text,
+    },
+
+    /// A block for list items.
+    ///
+    /// The list variant is controlled with the [`ListKind`] definition.
+    List {
+        kind: ListKind,
+        nodes: Vec<Node>,
+    },
+
+    /// A list item node that represents different list item variants including task items.
+    ///
+    /// The variant is controlled with the [`ItemKind`] definition. When [`ItemKind`] is [`None`]
+    /// the item should be interpreted as unordered list item: `"- Item"`.
+    Item {
+        text: Text,
+    },
+
+    TaskListItem {
+        kind: TaskListItemKind,
+        text: Text,
+    },
+}
+
+/// Returns `true` if the [`Tag`] should be closed upon encountering the given [`TagEnd`].
+fn matches_tag_end(tag: &Tag, tag_end: &TagEnd) -> bool {
+    matches!(
+        (tag, tag_end),
+        (Tag::Paragraph { .. }, TagEnd::Paragraph)
+            | (Tag::Heading { .. }, TagEnd::Heading(..))
+            | (Tag::BlockQuote { .. }, TagEnd::BlockQuote(..))
+            | (Tag::CodeBlock { .. }, TagEnd::CodeBlock)
+            | (Tag::List { .. }, TagEnd::List(..))
+            | (Tag::Item { .. }, TagEnd::Item)
+    )
+}
+
+/// Parses the given Markdown input into a list of [`Node`]s.
+///
+/// This is a convenience function for constructing a [`Parser`] and calling [`Parser::parse`].  
+///
+/// # Examples
+///
+/// ```
+/// use basalt_core::markdown::{from_str, Range, Node, MarkdownNode, HeadingLevel, Text};
+///
+/// let markdown = "# My Heading\n\nSome text.";
+/// let nodes = from_str(markdown);
+///
+/// assert_eq!(nodes, vec![
+///   Node {
+///     markdown_node: MarkdownNode::Heading {
+///       level: HeadingLevel::H1,
+///       text: Text::from("My Heading"),
+///     },
+///     source_range: Range { start: 0, end: 13 },
+///   },
+///   Node {
+///     markdown_node: MarkdownNode::Paragraph {
+///       text: Text::from("Some text."),
+///     },
+///     source_range: Range { start: 14, end: 24 },
+///   },
+/// ])
+/// ```
+pub fn from_str(text: &str) -> Vec<Node> {
+    Parser::new(text).parse()
+}
+
+/// A parser that consumes [`pulldown_cmark::Event`]s and produces a [`Vec`] of [`Node`].
+///
+/// # Examples
+///
+/// ```
+/// use basalt_core::markdown::{Parser, Range, Node, MarkdownNode, HeadingLevel, Text};
+///
+/// let markdown = "# My Heading\n\nSome text.";
+/// let parser = Parser::new(markdown);
+/// let nodes = parser.parse();
+///
+/// assert_eq!(nodes, vec![
+///   Node {
+///     markdown_node: MarkdownNode::Heading {
+///       level: HeadingLevel::H1,
+///       text: Text::from("My Heading"),
+///     },
+///     source_range: Range { start: 0, end: 13 },
+///   },
+///   Node {
+///     markdown_node: MarkdownNode::Paragraph {
+///       text: Text::from("Some text."),
+///     },
+///     source_range: Range { start: 14, end: 24 },
+///   },
+/// ])
+/// ```
+pub struct Parser<'a>(pulldown_cmark::TextMergeWithOffset<'a, pulldown_cmark::OffsetIter<'a>>);
+
+impl<'a> Iterator for Parser<'a> {
+    type Item = (Event<'a>, Range<usize>);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> Parser<'a> {
+    /// Creates a new [`Parser`] from a Markdown input string.
+    ///
+    /// The parser uses [`pulldown_cmark::Parser::new_ext`] with [`Options::all()`] and
+    /// [`pulldown_cmark::TextMergeWithOffset`] internally.
+    ///
+    /// The offset is required to know where the node appears in the provided source text.
+    pub fn new(text: &'a str) -> Self {
+        let parser = pulldown_cmark::TextMergeWithOffset::new(
+            pulldown_cmark::Parser::new_ext(text, Options::all()).into_offset_iter(),
+        );
+
+        Self(parser)
+    }
+
+    fn parse_tag(
+        tag: Tag,
+        events: &mut Peekable<Parser<'a>>,
+        source_range: Range<usize>,
+    ) -> Option<Node> {
+        match tag {
+            Tag::BlockQuote(kind) => Some(Node::new(
+                MarkdownNode::BlockQuote {
+                    kind: kind.map(|kind| kind.into()),
+                    nodes: Parser::parse_events(events, Some(tag)),
+                },
+                source_range,
+            )),
+            Tag::List(start) => Some(Node::new(
+                MarkdownNode::List {
+                    kind: start.map(ListKind::Ordered).unwrap_or(ListKind::Unordered),
+                    nodes: Parser::parse_events(events, Some(tag)),
+                },
+                source_range,
+            )),
+            Tag::Heading { level, .. } => Some(Node::new(
+                MarkdownNode::Heading {
+                    level: level.into(),
+                    text: Text::default(),
+                },
+                source_range,
+            )),
+            Tag::CodeBlock(_) => Some(Node::new(
+                MarkdownNode::CodeBlock {
+                    lang: None,
+                    text: Text::default(),
+                },
+                source_range,
+            )),
+            Tag::Paragraph => Some(Node::new(
+                MarkdownNode::Paragraph {
+                    text: Text::default(),
+                },
+                source_range,
+            )),
+            Tag::Item => Some(Node::new(
+                MarkdownNode::Item {
+                    text: Text::default(),
+                },
+                source_range,
+            )),
+            // NOTE: After all tags have been implemented the Option wrapper can be removed.
+            //
+            // Missing tags:
+            //
+            // | Tag::HtmlBlock
+            // | Tag::FootnoteDefinition(_)
+            // | Tag::Table(_)
+            // | Tag::TableHead
+            // | Tag::TableRow
+            // | Tag::TableCell
+            // | Tag::Emphasis
+            // | Tag::Strong
+            // | Tag::Strikethrough
+            // | Tag::Link { .. }
+            // | Tag::Image { .. }
+            // | Tag::MetadataBlock(_)
+            // | Tag::DefinitionList
+            // | Tag::DefinitionListTitle
+            // | Tag::Subscript
+            // | Tag::Superscript
+            // | Tag::DefinitionListDefinition
+            _ => None,
+        }
+    }
+
+    fn parse_events(events: &mut Peekable<Parser<'a>>, current_tag: Option<Tag>) -> Vec<Node> {
+        let mut nodes = Vec::new();
+
+        while let Some((event, range)) = events.peek().cloned() {
+            events.next();
+            match event {
+                Event::Start(tag) => {
+                    if let Some(node) = Parser::parse_tag(tag, events, range) {
+                        nodes.push(node);
+                    }
+                }
+                Event::End(tag_end) => {
+                    if let Some(ref tag) = current_tag {
+                        if matches_tag_end(tag, &tag_end) {
+                            return nodes;
+                        }
+                    }
+                }
+                Event::Text(text) => {
+                    if let Some(node) = nodes.last_mut() {
+                        node.push_text_node(text.to_string().into())
+                    }
+                }
+                Event::Code(text) => {
+                    if let Some(node) = nodes.last_mut() {
+                        node.push_text_node(TextNode::new(text.to_string(), Some(Style::Code)))
+                    }
+                }
+                Event::TaskListMarker(checked) => {
+                    if let Some(node) = nodes.last_mut() {
+                        let source_range = node.clone().source_range;
+
+                        if checked {
+                            *node = Node::new(
+                                MarkdownNode::TaskListItem {
+                                    kind: TaskListItemKind::Checked,
+                                    text: Text::default(),
+                                },
+                                source_range,
+                            );
+                        } else {
+                            *node = Node::new(
+                                MarkdownNode::TaskListItem {
+                                    kind: TaskListItemKind::Unchecked,
+                                    text: Text::default(),
+                                },
+                                source_range,
+                            );
+                        }
+                    }
+                }
+                // Missing events:
+                //
+                // | Event::InlineMath(_)
+                // | Event::DisplayMath(_)
+                // | Event::Html(_)
+                // | Event::InlineHtml(_)
+                // | Event::SoftBreak
+                // | Event::HardBreak
+                // | Event::Rule
+                // | Event::FootnoteReference(_)
+                _ => {}
+            }
+        }
+
+        nodes
+    }
+
+    /// Consumes the parser, processing all remaining events from the stream into a list of
+    /// [`Node`]s.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use basalt_core::markdown::{Parser, Node, MarkdownNode, Range, Text};
+    /// let parser = Parser::new("Hello world");
+    ///
+    /// let nodes = parser.parse();
+    ///
+    /// assert_eq!(nodes, vec![
+    ///   Node {
+    ///     markdown_node: MarkdownNode::Paragraph {
+    ///       text: Text::from("Hello world"),
+    ///     },
+    ///     source_range: Range { start: 0, end: 11 },
+    ///   },
+    /// ]);
+    /// ```
+    pub fn parse(self) -> Vec<Node> {
+        Parser::parse_events(&mut self.peekable(), None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    fn p(str: &str, range: Range<usize>) -> Node {
+        Node::new(MarkdownNode::Paragraph { text: str.into() }, range)
+    }
+
+    fn blockquote(nodes: Vec<Node>, range: Range<usize>) -> Node {
+        Node::new(MarkdownNode::BlockQuote { kind: None, nodes }, range)
+    }
+
+    fn list(kind: ListKind, nodes: Vec<Node>, range: Range<usize>) -> Node {
+        Node::new(MarkdownNode::List { kind, nodes }, range)
+    }
+
+    fn item(str: &str, range: Range<usize>) -> Node {
+        Node::new(MarkdownNode::Item { text: str.into() }, range)
+    }
+
+    fn unchecked_task(str: &str, range: Range<usize>) -> Node {
+        Node::new(
+            MarkdownNode::TaskListItem {
+                kind: TaskListItemKind::Unchecked,
+                text: str.into(),
+            },
+            range,
+        )
+    }
+
+    fn checked_task(str: &str, range: Range<usize>) -> Node {
+        Node::new(
+            MarkdownNode::TaskListItem {
+                kind: TaskListItemKind::Checked,
+                text: str.into(),
+            },
+            range,
+        )
+    }
+
+    fn heading(level: HeadingLevel, str: &str, range: Range<usize>) -> Node {
+        Node::new(
+            MarkdownNode::Heading {
+                level,
+                text: str.into(),
+            },
+            range,
+        )
+    }
+
+    fn h1(str: &str, range: Range<usize>) -> Node {
+        heading(HeadingLevel::H1, str, range)
+    }
+
+    fn h2(str: &str, range: Range<usize>) -> Node {
+        heading(HeadingLevel::H2, str, range)
+    }
+
+    fn h3(str: &str, range: Range<usize>) -> Node {
+        heading(HeadingLevel::H3, str, range)
+    }
+
+    fn h4(str: &str, range: Range<usize>) -> Node {
+        heading(HeadingLevel::H4, str, range)
+    }
+
+    fn h5(str: &str, range: Range<usize>) -> Node {
+        heading(HeadingLevel::H5, str, range)
+    }
+
+    fn h6(str: &str, range: Range<usize>) -> Node {
+        heading(HeadingLevel::H6, str, range)
+    }
+
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        let tests = [
+            (
+                indoc! {r#"# Heading 1
+
+                ## Heading 2
+
+                ### Heading 3
+
+                #### Heading 4
+
+                ##### Heading 5
+
+                ###### Heading 6
+                "#},
+                vec![
+                    h1("Heading 1", 0..12),
+                    h2("Heading 2", 13..26),
+                    h3("Heading 3", 27..41),
+                    h4("Heading 4", 42..57),
+                    h5("Heading 5", 58..74),
+                    h6("Heading 6", 75..92),
+                ],
+            ),
+            // // TODO: Implement correct test case when `- [?] ` task item syntax is supported
+            // // Now we interpret it as a regular item
+            (
+                indoc! { r#"- [ ] Task
+                - [x] Completed task
+                - [?] Completed task
+                "#},
+                vec![list(
+                    ListKind::Unordered,
+                    vec![
+                        unchecked_task("Task", 0..11),
+                        checked_task("Completed task", 11..32),
+                        item("[?] Completed task", 32..53),
+                    ],
+                    0..53,
+                )],
+            ),
+            (
+                indoc! {r#"You _can_ quote text by adding a `>` symbols before the text.
+                > Human beings face ever more complex and urgent problems, and their effectiveness in dealing with these problems is a matter that is critical to the stability and continued progress of society.
+                > > > Deep Quote
+                >
+                > - Doug Engelbart, 1961
+                "#},
+                vec![
+                    Node::new(MarkdownNode::Paragraph {
+                        text: vec![
+                            TextNode::new("You ".into(), None),
+                            TextNode::new("can".into(), None),
+                            TextNode::new(" quote text by adding a ".into(), None),
+                            TextNode::new(">".into(), Some(Style::Code)),
+                            TextNode::new(" symbols before the text.".into(), None),
+                        ]
+                        .into(),
+                    }, 0..62),
+                    blockquote(
+                        vec![
+                            p("Human beings face ever more complex and urgent problems, and their effectiveness in dealing with these problems is a matter that is critical to the stability and continued progress of society.", 64..257),
+                            blockquote(
+                                vec![blockquote(vec![p("Deep Quote", 263..274)], 261..274)],
+                                259..274,
+                            ),
+                            list(
+                                ListKind::Unordered,
+                                vec![item("Doug Engelbart, 1961", 278..301)],
+                                278..301,
+                            ),
+                        ],
+                        62..301,
+                    ),
+                ],
+            ),
+        ];
+
+        tests
+            .iter()
+            .for_each(|test| assert_eq!(from_str(test.0), test.1));
+    }
+}

--- a/basalt/src/markdown/state.rs
+++ b/basalt/src/markdown/state.rs
@@ -1,0 +1,63 @@
+use ratatui::widgets::ScrollbarState;
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Scrollbar {
+    pub state: ScrollbarState,
+    pub position: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct MarkdownViewState {
+    pub(crate) text: String,
+    pub(crate) scrollbar: Scrollbar,
+}
+
+impl MarkdownViewState {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.into(),
+            ..Default::default()
+        }
+    }
+
+    pub fn get_lines(&self) -> Vec<&str> {
+        self.text.lines().collect()
+    }
+
+    pub fn scroll_up(self, amount: usize) -> Self {
+        let new_position = self.scrollbar.position.saturating_sub(amount);
+        let new_state = self.scrollbar.state.position(new_position);
+
+        Self {
+            scrollbar: Scrollbar {
+                state: new_state,
+                position: new_position,
+            },
+            ..self
+        }
+    }
+
+    pub fn scroll_down(self, amount: usize) -> Self {
+        let new_position = self.scrollbar.position.saturating_add(amount);
+        let new_state = self.scrollbar.state.position(new_position);
+
+        Self {
+            scrollbar: Scrollbar {
+                state: new_state,
+                position: new_position,
+            },
+            ..self
+        }
+    }
+
+    pub fn set_text(self, text: String) -> Self {
+        Self { text, ..self }
+    }
+
+    pub fn reset_scrollbar(self) -> Self {
+        Self {
+            scrollbar: Scrollbar::default(),
+            ..self
+        }
+    }
+}

--- a/basalt/src/markdown/view.rs
+++ b/basalt/src/markdown/view.rs
@@ -1,0 +1,253 @@
+//! # Markdown View Widget
+//!
+//! This module provides a widget called `MarkdownView` that can render Markdown content into
+//! terminal user interface (TUI) structures using the [`ratatui`](https://docs.rs/ratatui) crate.
+//! It integrates with a [`super::state::MarkdownViewState`] to manage scrolling and additional
+//! metadata.
+//!
+//! The module uses markdown parser [`basalt_core::markdown`] to produce
+//! [`basalt_core::markdown::Node`] values. Each node is converted to one or more
+//! [`ratatui::text::Line`] objects.
+//!
+//! Example of rendered output
+//!
+//! ██ Headings
+//!
+//! █ This is a heading 1
+//!
+//! ██ This is a heading 2
+//!
+//! ▓▓▓ This is a heading 3
+//!
+//! ▓▓▓▓ This is a heading 4
+//!
+//! ▓▓▓▓▓ This is a heading 5
+//!
+//! ░░░░░░ This is a heading 6
+//!
+//! ██ Quotes
+//!
+//! You can quote text by adding a > symbols before the text.
+//!
+//! ┃ Human beings face ever more complex and urgent problems, and their effectiveness in dealing with these problems is a matter that is critical to the stability and continued progress of society.
+//! ┃
+//! ┃ - Doug Engelbart, 1961
+//!
+//! ██ Bold, italics, highlights
+//!
+//! This line will not be bold
+//!
+//! \*\*This line will not be bold\*\*
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Stylize},
+    text::{Line, Span},
+    widgets::{
+        self, Block, BorderType, Paragraph, ScrollbarOrientation, StatefulWidget,
+        StatefulWidgetRef, Widget,
+    },
+};
+
+use super::parser;
+
+use super::state::MarkdownViewState;
+
+/// A widget for rendering markdown text using [`MarkdownViewState`].
+///
+/// # Example
+///
+/// ```rust
+/// use basalt_core::markdown;
+/// use basalt_widgets::markdown::{MarkdownViewState, MarkdownView};
+/// use ratatui::prelude::*;
+/// use ratatui::widgets::StatefulWidgetRef;
+///
+/// let text = "# Hello, world!\nThis is a test.";
+/// let mut state = MarkdownViewState::new(text);
+///
+/// let area = Rect::new(0, 0, 20, 10);
+/// let mut buffer = Buffer::empty(area);
+///
+/// MarkdownView.render_ref(area, &mut buffer, &mut state);
+///
+/// let expected = [
+///   "╭──────────────────▲",
+///   "│█ Hello, world!   █",
+///   "│                  █",
+///   "│This is a test.   █",
+///   "│                  █",
+///   "│                  █",
+///   "│                  █",
+///   "│                  ║",
+///   "│                  ║",
+///   "╰──────────────────▼",
+/// ];
+///
+/// // FIXME: Take styles into account
+/// // assert_eq!(buffer, Buffer::with_lines(expected));
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct MarkdownView;
+
+impl MarkdownView {
+    fn heading(level: parser::HeadingLevel, content: Vec<Span>) -> Line {
+        let prefix = match level {
+            parser::HeadingLevel::H1 => Span::from("█ ").blue(),
+            parser::HeadingLevel::H2 => Span::from("██ ").cyan(),
+            parser::HeadingLevel::H3 => Span::from("▓▓▓ ").green(),
+            parser::HeadingLevel::H4 => Span::from("▓▓▓▓ ").yellow(),
+            parser::HeadingLevel::H5 => Span::from("▓▓▓▓▓ ").red(),
+            parser::HeadingLevel::H6 => Span::from("░░░░░░ ").red(),
+        };
+        Line::from([prefix].into_iter().chain(content).collect::<Vec<_>>()).bold()
+    }
+
+    fn task<'a>(
+        kind: parser::TaskListItemKind,
+        content: Vec<Span<'a>>,
+        prefix: Span<'a>,
+    ) -> Line<'a> {
+        match kind {
+            parser::TaskListItemKind::Unchecked => Line::from(
+                [prefix, "󰄱 ".black()]
+                    .into_iter()
+                    .chain(content)
+                    .collect::<Vec<_>>(),
+            ),
+            parser::TaskListItemKind::Checked => Line::from(
+                [prefix, "󰄲 ".magenta()]
+                    .into_iter()
+                    .chain(content)
+                    .collect::<Vec<_>>(),
+            )
+            .black()
+            .add_modifier(Modifier::CROSSED_OUT),
+            // parser::TaskListItemKind::LooselyChecked => Line::from(
+            //     [prefix, "󰄲 ".magenta()]
+            //         .into_iter()
+            //         .chain(content)
+            //         .collect::<Vec<_>>(),
+            // ),
+        }
+    }
+
+    fn item<'a>(kind: parser::ItemKind, content: Vec<Span<'a>>, prefix: Span<'a>) -> Line<'a> {
+        match kind {
+            // parser::ItemKind::Ordered(num) => Line::from(
+            //     [prefix, num.to_string().black(), ". ".into()]
+            //         .into_iter()
+            //         .chain(content)
+            //         .collect::<Vec<_>>(),
+            // ),
+            parser::ItemKind::Unordered => Line::from(
+                [prefix, "- ".black()]
+                    .into_iter()
+                    .chain(content)
+                    .collect::<Vec<_>>(),
+            ),
+        }
+    }
+
+    fn text_to_spans<'a>(text: parser::Text) -> Vec<Span<'a>> {
+        text.into_iter()
+            .map(|text| Span::from(text.content))
+            .collect()
+    }
+
+    fn code_block<'a>(text: parser::Text) -> Vec<Line<'a>> {
+        text.into_iter()
+            .flat_map(|text| {
+                text.content
+                    .clone()
+                    .split("\n")
+                    .map(String::from)
+                    .collect::<Vec<String>>()
+            })
+            .map(|text| Line::from(text).red().bg(Color::Rgb(10, 10, 10)))
+            .collect()
+    }
+
+    fn render_markdown<'a>(node: parser::Node, prefix: Span<'a>) -> Vec<Line<'a>> {
+        match node.markdown_node {
+            parser::MarkdownNode::Paragraph { text } => {
+                let mut spans = MarkdownView::text_to_spans(text);
+                spans.insert(0, prefix.clone());
+                vec![spans.into(), Line::default()]
+            }
+            parser::MarkdownNode::Heading { level, text } => [
+                MarkdownView::heading(level, MarkdownView::text_to_spans(text)),
+                Line::default(),
+            ]
+            .to_vec(),
+            parser::MarkdownNode::Item { text } => [MarkdownView::item(
+                parser::ItemKind::Unordered,
+                MarkdownView::text_to_spans(text),
+                prefix,
+            )]
+            .to_vec(),
+            parser::MarkdownNode::TaskListItem { kind, text } => [MarkdownView::task(
+                kind,
+                MarkdownView::text_to_spans(text),
+                prefix,
+            )]
+            .to_vec(),
+            // TODO: Add lang support and syntax highlighting
+            parser::MarkdownNode::CodeBlock { text, .. } => {
+                let lines = MarkdownView::code_block(text);
+                lines
+            }
+            parser::MarkdownNode::List { nodes, .. } => {
+                let mut lines = nodes
+                    .into_iter()
+                    .flat_map(|child| MarkdownView::render_markdown(child, prefix.clone()))
+                    .collect::<Vec<Line<'a>>>();
+
+                lines.push(Line::default());
+
+                lines
+            }
+            // TODO: Support callout block quote types
+            parser::MarkdownNode::BlockQuote { nodes, .. } => {
+                let lines = nodes
+                    .into_iter()
+                    .flat_map(|child| {
+                        MarkdownView::render_markdown(child, Span::from("┃ ").magenta())
+                            .into_iter()
+                            .chain(vec![Line::from(prefix.clone())])
+                            .collect::<Vec<_>>()
+                    })
+                    .map(|line| line.dark_gray())
+                    .collect::<Vec<Line<'a>>>();
+
+                lines
+            }
+        }
+    }
+}
+
+impl StatefulWidgetRef for MarkdownView {
+    type State = MarkdownViewState;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let nodes = parser::from_str(&state.text)
+            .into_iter()
+            .flat_map(|node| MarkdownView::render_markdown(node, Span::default()))
+            .collect::<Vec<Line<'_>>>();
+
+        let mut scroll_state = state.scrollbar.state.content_length(nodes.len());
+
+        let root_node = Paragraph::new(nodes)
+            .block(Block::bordered().border_type(BorderType::Rounded))
+            .scroll((state.scrollbar.position as u16, 0));
+
+        Widget::render(root_node, area, buf);
+
+        StatefulWidget::render(
+            widgets::Scrollbar::new(ScrollbarOrientation::VerticalRight),
+            area,
+            buf,
+            &mut scroll_state,
+        );
+    }
+}

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 cargo check --profile ci
-cargo clippy --profile ci --workspace --all-targets
+cargo clippy --profile ci --workspace --all-targets -- -D warnings
 cargo test --profile ci --workspace --all-targets


### PR DESCRIPTION
#### [Refactor markdown event parsing](https://github.com/erikjuhani/basalt/commit/7115dfa48368f55a12e3a359c1941026ab203933)
> The biggest change introduced by this commit is the refactored event
> parsing function that is now recursive and builds the markdown node tree
> as deep as it is required for instance block quotes can be nested in
> Markdown. Previous implementation did that support this easily and was
> not very practical to be building up from, thus the logic was changed to
> something that hopefully is easier to modify in the future.
> 
> The another big change here is the move of Markdown parser and markdown
> widget directly under basalt workspace. This enables faster iteration as
> I don't have to release the other workspaces constantly. So many things
> are still in flux, so I want to keep the mundane things minimal.
> Eventually these modules will be moved under the basalt-core and
> basalt-widgets crates.
> 
> The original implementation for Markdown parser and view were kept in
> place for now.
> 
> There are some other things that had to be changed due to this
> modification, like the `ItemKind` and `TaskListItem` variants. These
> changes were reflected to the markdown widget as well.