### PR TITLE
Markdown parser support loosely checked task

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [Refactor markdown event parsing](https://github.com/erikjuhani/basalt/commit/7115dfa48368f55a12e3a359c1941026ab203933)
+- [Support loosely checked task items](https://github.com/erikjuhani/basalt/commit/7e14b39fc2b14942ea873377e591adf06cf261bf)
 
 ## 0.3.1
 

--- a/basalt/src/markdown/view.rs
+++ b/basalt/src/markdown/view.rs
@@ -123,12 +123,12 @@ impl MarkdownView {
             )
             .black()
             .add_modifier(Modifier::CROSSED_OUT),
-            // parser::TaskListItemKind::LooselyChecked => Line::from(
-            //     [prefix, "󰄲 ".magenta()]
-            //         .into_iter()
-            //         .chain(content)
-            //         .collect::<Vec<_>>(),
-            // ),
+            parser::TaskListItemKind::LooselyChecked => Line::from(
+                [prefix, "󰄲 ".magenta()]
+                    .into_iter()
+                    .chain(content)
+                    .collect::<Vec<_>>(),
+            ),
         }
     }
 


### PR DESCRIPTION
#### [Add support for `LooselyChecked` task kind](https://github.com/erikjuhani/basalt/commit/7e14b39fc2b14942ea873377e591adf06cf261bf)

> The loosely checked task type references to Obsidian flavor of
> checkmarking tasks with any other character than `x`.
> 
> ```markdown
> - [x] Properly checked
> - [ ] Unchecked
> - [-] Loosely checked
> - [.] Loosely checked
> ```
> 
> The loosely checked task item is determined in the text event, since
> it's not parsed by pulldown-cmark parser. The implementation itself
> reads the first four characters of the text payload in the text event
> and then compares it to the following character sequence `[,_,], ` (space
> is important so that we trim it away, and it's actually a valid task
> item). If we match we define the current node as loosely checked task
> item.