### PR TITLE
Ordered list

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - [Refactor markdown event parsing](https://github.com/erikjuhani/basalt/commit/7115dfa48368f55a12e3a359c1941026ab203933)
 - [Support loosely checked task items](https://github.com/erikjuhani/basalt/commit/7e14b39fc2b14942ea873377e591adf06cf261bf)
+- [Add support for ordered lists](https://github.com/erikjuhani/basalt/commit/7f715bb04c66066959588abfca5f29a3b3df22a7)
+
+### Changed
+
+- [Change checkbox symbol (#30)](https://github.com/erikjuhani/basalt/commit/11b944cbca19a020d984fbb272724ec80d1119e0)
 
 ## 0.3.1
 

--- a/basalt/src/markdown/parser.rs
+++ b/basalt/src/markdown/parser.rs
@@ -72,10 +72,8 @@ pub enum Style {
 /// Represents the variant of a list or task item (checked, unchecked, etc.).
 #[derive(Clone, Debug, PartialEq)]
 pub enum ItemKind {
-    // TODO: Ordered list
-    //
     // An ordered list item (e.g., `1. item`), storing the numeric index.
-    // Ordered(u64),
+    Ordered(u64),
     /// An unordered list item (e.g., `- item`).
     Unordered,
 }
@@ -87,8 +85,6 @@ pub enum TaskListItemKind {
     Checked,
     /// A checkbox item that is unchecked using `- [ ]`.
     Unchecked,
-    // TODO: Loose check
-    //
     /// A checkbox item that is checked, but not explicitly recognized as
     /// `Checked` (e.g., `- [?]`).
     LooselyChecked,


### PR DESCRIPTION
[Add support for ordered lists](https://github.com/erikjuhani/basalt/commit/7f715bb04c66066959588abfca5f29a3b3df22a7)

Ordered lists are now displayed properly with the starting index.