### PR TITLE
Use config_dir() to locate obsidian.json on Windows

### DIFF
--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -1,4 +1,4 @@
-use dirs::config_local_dir;
+use dirs::config_dir;
 
 use serde::{Deserialize, Deserializer};
 use std::path::Path;
@@ -198,5 +198,5 @@ fn obsidian_config_dir() -> Option<PathBuf> {
     #[cfg(target_os = "windows")]
     const OBSIDIAN_CONFIG_DIR_NAME: &str = "Obsidian";
 
-    config_local_dir().map(|config_path| config_path.join(OBSIDIAN_CONFIG_DIR_NAME))
+    config_dir().map(|config_path| config_path.join(OBSIDIAN_CONFIG_DIR_NAME))
 }


### PR DESCRIPTION
[config_dir()](https://pop-os.github.io/libcosmic/dirs/fn.config_dir.html) returns `%APPDATA%` for Windows, while [config_local_dir()](https://pop-os.github.io/libcosmic/dirs/fn.config_local_dir.html) returns `%LOCALAPPDATA%`.

[Obsidian docs](https://help.obsidian.md/data-storage#Global+settings) confirm `%APPDATA%` is where `obsidian.json` should live on Windows.

`config_dir()` returns the same directories as `config_local_dir()` on Mac and Linux, so this shouldn't affect those platforms. 

Running the `basalt` from `target\debug\basalt.exe` works on my PC after this change. I ran tests and they came back ok, but I've only tested this on my Windows machine.