### PR TITLE
Fix offset panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "basalt-tui"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "basalt-core",
  "basalt-widgets",

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.6 (2025-05-21)
+
+### Fixed
+
+- [Fix panic, when there are no notes inside a vault](https://github.com/erikjuhani/basalt/commit/4644f90a595f8000e983475b78e0d3605a5bc16e)
+
 ## 0.3.5
 
 ### Fixed

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -6,7 +6,7 @@ Basalt TUI application for Obsidian notes.
 readme = "../README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
[Fix panic, when there are no notes inside a vault](https://github.com/erikjuhani/basalt/commit/4644f90a595f8000e983475b78e0d3605a5bc16e)

This was caused by a subtraction of 1 from usize 0. The 0 was present
when no notes were found inside the vault.

Moved calculate offset out of the SidePanelState impl to make it more
generic and pure.

Fixes https://github.com/erikjuhani/basalt/issues/10