### PR TITLE
Use a regular loop instead of recursion for rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "basalt-tui"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "basalt-core",
  "basalt-widgets",

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
-## Unreleased
+## 0.3.7 (2025-05-22)
+
+### Added
 
 - [Add `stylized_text` module](https://github.com/erikjuhani/basalt/commit/47db925ef858831672be69fb11bcf272522e1b3a)
 - [Add `lib.rs` which allows basalt to be used as a library](https://github.com/erikjuhani/basalt/commit/ce094ed8aab1945aad36955bce83eeea09085177)
+
+### Fixed
+
+- [Use a regular loop instead of recursion for rendering](https://github.com/erikjuhani/basalt/commit/4d9e6c83f2342b12501c2f316dbab05ab68119ab)
 
 ## 0.3.6 (2025-05-21)
 

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -6,7 +6,7 @@ Basalt TUI application for Obsidian notes.
 readme = "../README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 
 [dependencies]

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -236,13 +236,16 @@ impl<'a> App<'a> {
         .run(state)
     }
 
-    fn run(&mut self, state: AppState<'a>) -> Result<()> {
-        self.draw(&state)?;
-        let event = &event::read()?;
-        match self.update(&state, self.handle_event(event)) {
-            state if state.is_running => self.run(state),
-            _ => Ok(()),
+    fn run(&mut self, mut state: AppState<'a>) -> Result<()> {
+        loop {
+            self.draw(&state)?;
+            if !state.is_running {
+                break;
+            }
+            let event = event::read()?;
+            state = self.update(&state, self.handle_event(&event));
         }
+        Ok(())
     }
 
     fn update_help_modal(


### PR DESCRIPTION
The recursion can lead to stack overflow if not tail-call optimized, so, using a regular loop here is the preferred way. This potentially already caused a stack-overflow, see #41.