### PR TITLE
Improve obsidian config logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "basalt-core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "dirs",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -150,23 +150,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -462,13 +462,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -634,31 +634,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -749,20 +729,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -771,22 +742,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -795,21 +751,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -819,21 +769,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -849,21 +787,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -873,21 +799,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "basalt-tui"
-version = "0.3.7"
+version = "0.4.0"
 dependencies = [
  "basalt-core",
  "basalt-widgets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 basalt = { path = "basalt", version = "0.3.1" }
-basalt-core = { path = "basalt-core", version = "0.4.3" }
+basalt-core = { path = "basalt-core", version = "0.5.0" }
 basalt-widgets = { path = "basalt-widgets", version = "0.1.1" }
 
 [profile.ci]

--- a/basalt-core/CHANGELOG.md
+++ b/basalt-core/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.5.0 (2025-05-25)
+
+### obsidian
+
+#### Breaking
+
+- [Return `Vec` instead of `Iterator` from `notes()`](https://github.com/erikjuhani/basalt/commit/d56f2529971f54e8931f31ed32e2651087050c24)
+- [Remove `created` field from Note as obsolete](https://github.com/erikjuhani/basalt/commit/fa17bf67ed13f002b8a97c259c18013a19756907)
+
+#### Changed
+
+- [Use try_exists in load_from for global Obsidian config](https://github.com/erikjuhani/basalt/commit/9f5359ddf38b9b3482f066c3b3bbc3339d4fb2ff)
+
+#### Fixed
+
+- [Get all potential obsidian global config locations](https://github.com/erikjuhani/basalt/commit/a5136b18ea87d00c5ca53bb539910df22582f260)
+
 ## 0.4.3 (2025-05-21)
 
 ### Fixed

--- a/basalt-core/Cargo.toml
+++ b/basalt-core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.4.3"
 edition = "2021"
 
 [dependencies]
-dirs = "5.0.1"
+dirs = "6.0.0"
 thiserror = "2.0.11"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0"

--- a/basalt-core/Cargo.toml
+++ b/basalt-core/Cargo.toml
@@ -6,7 +6,7 @@ Provides the core functionality for Basalt TUI application
 readme = "README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -53,8 +53,18 @@ impl ObsidianConfig {
     /// _ = ObsidianConfig::load_from(Path::new("./dir-with-config-file"));
     /// ```
     pub fn load_from(config_path: &Path) -> Result<Self> {
-        let contents = fs::read_to_string(config_path.join("obsidian.json"))?;
-        Ok(serde_json::from_str(&contents)?)
+        let obsidian_json_path = config_path.join("obsidian.json");
+
+        if obsidian_json_path.try_exists()? {
+            let contents = fs::read_to_string(obsidian_json_path)?;
+            serde_json::from_str(&contents).map_err(Error::Json)
+        } else {
+            // TODO: Maybe a different error should be propagated in this case. E.g. 'unreadable'
+            // file.
+            Err(Error::PathNotFound(
+                obsidian_json_path.to_string_lossy().to_string(),
+            ))
+        }
     }
 
     /// Returns an iterator over the vaults in the configuration.

--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -1,9 +1,9 @@
-use dirs::config_dir;
+use dirs::{config_dir, home_dir};
 
 use serde::{Deserialize, Deserializer};
 use std::path::Path;
-use std::result;
 use std::{collections::BTreeMap, fs, path::PathBuf};
+use std::{env, result};
 
 use crate::obsidian::{Error, Result, Vault};
 
@@ -19,9 +19,24 @@ impl ObsidianConfig {
     ///
     /// Returns an [`Error`] if the filepath doesn't exist or JSON parsing failed.
     pub fn load() -> Result<Self> {
-        obsidian_config_dir()
-            .map(|path_buf| ObsidianConfig::load_from(&path_buf))
-            .ok_or(Error::PathNotFound("Obsidian config directory".to_string()))?
+        let config_locations = obsidian_global_config_locations();
+        let existing_config_locations = config_locations
+            .iter()
+            .filter(|path| path.is_dir())
+            .collect::<Vec<_>>();
+
+        if let Some(config_dir) = existing_config_locations.first() {
+            ObsidianConfig::load_from(config_dir)
+        } else {
+            Err(Error::PathNotFound(format!(
+                "Obsidian config directory was not found from these locations: {}",
+                config_locations
+                    .iter()
+                    .map(|path| path.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )))
+        }
     }
 
     /// Attempts to load `obsidian.json` file as an [`ObsidianConfig`] from the given directory
@@ -183,20 +198,77 @@ impl<'de> Deserialize<'de> for ObsidianConfig {
     }
 }
 
-/// Returns the system path to Obsidian's config folder, if any.
+/// Returns all existing configuration directory paths where Obsidian might store its global
+/// settings.
+///
+/// This function determines possible configuration locations by platform-specific conventions and
+/// installation methods. On all platforms, it first checks if the user has defined the
+/// `OBSIDIAN_CONFIG_DIR` environment variable. If so, that path is used, and any leading tilde (~)
+/// is expanded to the current user's home directory.
+///
+/// On Windows, it then resolves to the default Obsidian directory located under the system's
+/// application data folder, typically `%APPDATA%\Obsidian`. On macOS, the function expects to find
+/// the configuration under `~/Library/Application Support/obsidian`. On Linux, the standard config
+/// directory is assumed to be `$XDG_CONFIG_HOME/obsidian`, or `~/.config/obsidian`.
+///
+/// For Linux users, the function also accounts for sandboxed installations. If Obsidian is
+/// installed via Flatpak, the configuration is likely found in
+/// `~/.var/app/md.obsidian.Obsidian/config/obsidian`. For Snap installations, the relevant path is
+/// typically `~/snap/obsidian/common/.config/obsidian`.
 ///
 /// For reference:
 /// - macOS:  `/Users/username/Library/Application Support/obsidian`
 /// - Windows: `%APPDATA%\Obsidian\`
-/// - Linux:   `$XDG_CONFIG_HOME/obsidian/` or `~/.config/obsidian/`
+/// - Linux:   `$XDG_CONFIG_HOME/obsidian` or `~/.config/obsidian`
+///   flatpak: `$HOME/.var/app/md.obsidian.Obsidian/config/obsidian`
+///   snap: `$HOME/snap/obsidian/common/.config/obsidian`
 ///
 /// More info: [https://help.obsidian.md/Files+and+folders/How+Obsidian+stores+data]
-fn obsidian_config_dir() -> Option<PathBuf> {
+pub fn obsidian_global_config_locations() -> Vec<PathBuf> {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     const OBSIDIAN_CONFIG_DIR_NAME: &str = "obsidian";
 
     #[cfg(target_os = "windows")]
     const OBSIDIAN_CONFIG_DIR_NAME: &str = "Obsidian";
 
-    config_dir().map(|config_path| config_path.join(OBSIDIAN_CONFIG_DIR_NAME))
+    let override_path =
+        env::var("OBSIDIAN_CONFIG_DIR")
+            .ok()
+            .zip(home_dir())
+            .map(|(path, home_dir)| {
+                PathBuf::from(path.replace("~", home_dir.to_string_lossy().as_ref()))
+            });
+
+    let default_config_path =
+        config_dir().map(|config_path| config_path.join(OBSIDIAN_CONFIG_DIR_NAME));
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    let sandboxed_paths: [Option<PathBuf>; 0] = [];
+
+    // In cases where user has a sandboxes instance of Obsidian installed under either flatpak or
+    // snap, we must check if the configuration exists under these locations.
+    #[cfg(target_os = "linux")]
+    let sandboxed_paths = {
+        let flatpak_path = home_dir().map(|home_dir| {
+            home_dir
+                .join(".var/app/md.obsidian.Obsidian/config")
+                .join(OBSIDIAN_CONFIG_DIR_NAME)
+        });
+
+        let snap_path = home_dir().map(|home_dir| {
+            home_dir
+                .join("snap/obsidian/common/.config")
+                .join(OBSIDIAN_CONFIG_DIR_NAME)
+        });
+
+        [flatpak_path, snap_path]
+    };
+
+    let base_paths = [override_path, default_config_path];
+
+    base_paths
+        .into_iter()
+        .chain(sandboxed_paths)
+        .flatten()
+        .collect()
 }

--- a/basalt-core/src/obsidian/note.rs
+++ b/basalt-core/src/obsidian/note.rs
@@ -1,30 +1,15 @@
-use std::{fs, path::PathBuf, time::SystemTime};
+use std::{fs, path::PathBuf};
 
 use crate::obsidian::{Error, Result};
 
 /// Represents a single note (Markdown file) within a vault.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Note {
     /// The base filename without `.md` extension.
     pub name: String,
 
     /// Filesystem path to the `.md` file.
     pub path: PathBuf,
-
-    /// File creation time.
-    ///
-    /// TODO: Use chrono or time crates for better time format handling
-    pub created: SystemTime,
-}
-
-impl Default for Note {
-    fn default() -> Self {
-        Self {
-            name: String::default(),
-            path: PathBuf::default(),
-            created: SystemTime::UNIX_EPOCH,
-        }
-    }
 }
 
 impl Note {
@@ -38,7 +23,6 @@ impl Note {
     /// let note = Note {
     ///     name: "Example".to_string(),
     ///     path: "path/to/Example.md".into(),
-    ///     ..Default::default()
     /// };
     ///
     /// _ = Note::read_to_string(&note);
@@ -47,7 +31,7 @@ impl Note {
         fs::read_to_string(&note.path).map_err(Error::Io)
     }
 
-    /// Writes given content to notes path.
+    /// Replaces the content in the notes' markdown file with the given content.
     ///
     /// # Examples
     ///
@@ -57,7 +41,6 @@ impl Note {
     /// let note = Note {
     ///     name: "Example".to_string(),
     ///     path: "path/to/Example.md".into(),
-    ///     ..Default::default()
     /// };
     ///
     /// _ = Note::write(&note, String::from("# Heading"));

--- a/basalt-core/src/obsidian/vault.rs
+++ b/basalt-core/src/obsidian/vault.rs
@@ -28,7 +28,7 @@ pub struct Vault {
 }
 
 impl Vault {
-    /// Returns an iterator over Markdown (`.md`) files in this vault as [`Note`] structs.
+    /// Returns a [`Vec`] of Markdown (`.md`) files in this vault as [`Note`] structs.
     ///
     /// # Examples
     ///
@@ -41,13 +41,14 @@ impl Vault {
     ///     ..Default::default()
     /// };
     ///
-    /// assert_eq!(vault.notes().collect::<Vec<_>>(), vec![]);
+    /// assert_eq!(vault.notes(), vec![]);
     /// ```
-    pub fn notes(&self) -> impl Iterator<Item = Note> {
+    pub fn notes(&self) -> Vec<Note> {
         read_dir(&self.path)
             .into_iter()
             .flatten()
             .filter_map(|entry| Option::<Note>::from(DirEntry::from(entry.ok()?)))
+            .collect()
     }
 
     /// Returns a sorted vector [`Vec<Note>`] of all notes in the vault, sorted according to the
@@ -70,7 +71,7 @@ impl Vault {
     /// _ = vault.notes_sorted_by(alphabetically);
     /// ```
     pub fn notes_sorted_by(&self, compare: impl Fn(&Note, &Note) -> Ordering) -> Vec<Note> {
-        let mut notes: Vec<Note> = self.notes().collect();
+        let mut notes: Vec<Note> = self.notes();
         notes.sort_by(compare);
         notes
     }

--- a/basalt-core/src/obsidian/vault.rs
+++ b/basalt-core/src/obsidian/vault.rs
@@ -116,6 +116,12 @@ impl<'de> Deserialize<'de> for Vault {
 #[derive(Debug)]
 struct DirEntry(fs::DirEntry);
 
+impl AsRef<fs::DirEntry> for DirEntry {
+    fn as_ref(&self) -> &fs::DirEntry {
+        &self.0
+    }
+}
+
 impl From<fs::DirEntry> for DirEntry {
     fn from(value: fs::DirEntry) -> Self {
         DirEntry(value)
@@ -125,9 +131,7 @@ impl From<fs::DirEntry> for DirEntry {
 impl From<DirEntry> for Option<Note> {
     /// Transforms path with extension `.md` into [`Option<Note>`].
     fn from(value: DirEntry) -> Option<Note> {
-        let dir = value.0;
-        let created = dir.metadata().ok()?.created().ok()?;
-        let path = dir.path();
+        let path = value.as_ref().path();
 
         if path.extension()? != "md" {
             return None;
@@ -138,10 +142,6 @@ impl From<DirEntry> for Option<Note> {
             .file_name()
             .map(|file_name| file_name.to_string_lossy().into_owned())?;
 
-        Some(Note {
-            name,
-            path,
-            created,
-        })
+        Some(Note { name, path })
     }
 }

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0 (2025-05-25)
+
+### Fixed
+
+- [Update basalt-core to version 0.5.0](https://github.com/erikjuhani/basalt/commit/a30d611b79a98b661aabd27eca0c8caa69e27fa8), which potentially fixes #44
+
+Check basalt-core CHANGELOG [here](../basalt-core/CHANGELOG.md).
+
 ## 0.3.7 (2025-05-22)
 
 ### Added

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -6,11 +6,11 @@ Basalt TUI application for Obsidian notes.
 readme = "../README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.3.7"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]
-basalt-core = { workspace = true }
+basalt-core = { workspace = true, version = "0.5.0" }
 basalt-widgets = { workspace = true }
 ratatui = { version = "0.29.0", features = ["unstable-widget-ref"] }
 crossterm = "0.28.1"


### PR DESCRIPTION
#### [Get all potential obsidian global config locations](https://github.com/erikjuhani/basalt/commit/a5136b18ea87d00c5ca53bb539910df22582f260)

> Due to the nature of this functionality being reliant of another
> application called Obsidian, we must take into account possible
> sandboxed installations on Linux systems (e.g. flatpak, snap).
> 
> Additionally, this global config location can be controlled with an
> environment variable called `OBSIDIAN_CONFIG_DIR`, which can be given a
> `~` symbol to mark the home directory. The `~` symbol is transformed to
> the absolute home directory path.
> 
> The obsidian_global_config_locations() returns all potential directory
> paths for Obsidian.
> 
> On macOS and Windows we default to the regular paths defined in the
> Obsidian documentation:
> 
> - macOS: /Users/username/Library/Application Support/obsidian
> - Windows: %APPDATA%\Obsidian\
> 
> From this list of returned configs we filter out any paths that do not
> exist and then we select the first one, as the returned list is in order
> of priority:
> 
> 1. The `OBSIDIAN_CONFIG_DIR` environment variable
> 2. User config directory
> 3. Flatpak config
> 4. Snap config
> 
> If no paths can be certainly determined to be directories we fail with
> an error that displays all the configs we tried to access.
> 
> This change should fix https://github.com/erikjuhani/basalt/issues/44.

#### [Use try_exists in load_from for global Obsidian config](https://github.com/erikjuhani/basalt/commit/9f5359ddf38b9b3482f066c3b3bbc3339d4fb2ff)

> Previously we naively assumed that the config file exists, now a more
> explicit domain error is returned.

#### [Remove created field from Note as obsolete](https://github.com/erikjuhani/basalt/commit/fa17bf67ed13f002b8a97c259c18013a19756907)

> The existence of this field could result notes from being read into the
> program due to the fact that some systems do not support the file
> creation time metadata.
> 
> This functionality was now removed, since it was not in use in
> basalt-tui.

#### [Return Vec instead of Iterator from notes()](https://github.com/erikjuhani/basalt/commit/d56f2529971f54e8931f31ed32e2651087050c24)