### PR TITLE
Refactor state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "basalt-tui"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "basalt-core",
  "basalt-widgets",

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.0 (2025-06-15)
+
+### Changed
+
+- [Refactor state management](https://github.com/erikjuhani/basalt/commit/0d49afb9dd7078215ed3fb15ee6dea23da1c0ba9)
+
+### Added
+
+- [Add visiblity and visiblity helper methods to HelpModal](https://github.com/erikjuhani/basalt/commit/8f92863932325157ffe0e181470d194ee90b2a23)
+- [Add visibility and helper methods to VaultSelectorModal](https://github.com/erikjuhani/basalt/commit/1243a33d62d0cac04d2bb7556477e44867b491f8)
+- [Add active field to MarkdownView to indicate active state](https://github.com/erikjuhani/basalt/commit/5880a160f30628ebec4f6e043e97b83ccb8a1899)
+
 ## 0.6.1 (2025-06-07)
 
 ### Fixed

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -6,7 +6,7 @@ Basalt TUI application for Obsidian notes.
 readme = "../README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/basalt/src/explorer.rs
+++ b/basalt/src/explorer.rs
@@ -71,7 +71,11 @@ impl<'a> StatefulWidget for Explorer<'a> {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let block = Block::bordered()
-            .border_type(BorderType::Rounded)
+            .border_type(if state.active {
+                BorderType::Thick
+            } else {
+                BorderType::Rounded
+            })
             .title_style(Style::default().italic().bold());
 
         let Rect { height, .. } = block.inner(area);
@@ -177,7 +181,7 @@ mod tests {
                     Explorer::default().render(
                         frame.area(),
                         frame.buffer_mut(),
-                        &mut ExplorerState::new("Test", items).select().toggle_sort(),
+                        &mut ExplorerState::new("Test", items).select().sort(),
                     )
                 })
                 .unwrap();

--- a/basalt/src/help.txt
+++ b/basalt/src/help.txt
@@ -14,6 +14,7 @@
 ───────────────────────────────────────────────────────────────────────────────
             %version-notice
 
+
 DISCLAIMER
 
   Basalt is in its early stages, with a very limited set of features, and is
@@ -25,97 +26,110 @@ DISCLAIMER
   Quitting the application may feel a bit abrupt, as the application exits
   immediately after pressing ‹q›. I have some plans to handle this differently
   in the future. For example, through a series of button presses or by using
-  command inputs similar to Vims ‹:quit› or ‹:q›.
+  command inputs similar to Vim's ‹:quit› or ‹:q›.
 
 VAULT SELECTION
 
-  On startup screen you can select the Vault you want to view. Any vaults
-  considered open are shown with a ◆ symbol marker.
+  On startup screen you can select the Vault you want to view. Any open vaults
+  are shown with a ◆ symbol marker.
+
+    ‹q›         Quit the application
+    ‹?›         Show this help
+    ‹k›         Move selection up
+    ‹j›         Move selection down
+    ‹↩ Enter›   Select and open the highlighted vault
+
+  The vault selection can be brought up as a modal by hitting ‹Ctrl+G› after
+  the startup screen.
+
+INTERFACE
+
+  The application has two main panes: the Explorer (file browser) on the left
+  and the Note Viewer on the right. You can switch between these panes using
+  the Tab key. The currently active pane will be highlighted and name of the
+  active pane is displayed in the lower left corner of the application.
+
+  EXPLORER PANE
+
+    Browse and select notes from your vault.
+
+    The explorer shows all notes and folders in your vault. You can navigate up
+    and down through the list, and press Enter to select and view a note. The
+    explorer panel can be toggled on/off to give more space to the note viewer.
 
       ‹q›         Quit the application
       ‹?›         Show this help
-      ‹k›         Move selection up
-      ‹j›         Move selection down
-      ‹↩ Enter›   Select and open the highlighted vault
+      ‹Esc›       Cancel/close modals
+      ‹Tab›       Switch to note viewer pane
+      ‹k / j›     Move selection up / down
+      ‹↑ / ↓›     Move selection up / down
+      ‹s›         Toggle note sorting
+      ‹t›         Toggle explorer panel visibility
+      ‹↩ Enter›   Select and view the highlighted note
 
-  The vault selection can be brought up as a modal by hitting ‹Space› after
-  startup screen.
+      ‹Ctrl+G›    Toggle vault selector modal
+      ‹Ctrl+B›    Toggle explorer panel visibility
+      ‹Ctrl+U›    Scroll up half a page
+      ‹Ctrl+D›    Scroll down half a page
 
-MODES
+  NOTE VIEWER PANE
 
-  The current mode is displayed in the bottom-left corner of the UI.
+    Read and navigate through your selected note.
 
-  The distinction between the SELECT and NORMAL modes is that in SELECT mode,
-  you can browse and preview the notes in the vault, and in NORMAL mode, you
-  can navigate the content of a single selected note. Scrolling the notes work
-  in both modes.
+    The note viewer displays the content of the selected note in a readable
+    format. You can scroll through the content using the arrow keys or
+    vim-style navigation.
 
-  SELECT
-          Navigate the vault's notes.
+      ‹q›         Quit the application
+      ‹?›         Show this help
+      ‹Esc›       Cancel/close modals
+      ‹Tab›       Switch to explorer pane
+      ‹k / j›     Scroll up / down
+      ‹↑ / ↓›     Scroll up / down
+      ‹t›         Toggle explorer panel visibility
 
-          In SELECT mode, the vault contents can be selected by pressing Enter
-          or Return key. The list can be traversed up or down using ‹j› for
-          down and ‹k› for up. To change to NORMAL mode and hide the side
-          panel, press ‹t›.
+      ‹Ctrl+G›    Toggle vault selector modal
+      ‹Ctrl+B›    Toggle explorer panel visibility
+      ‹Ctrl+U›    Scroll up half a page
+      ‹Ctrl+D›    Scroll down half a page
 
-            ‹q›         Quit the application
-            ‹?›         Show this help
-            ‹t›         Toggle side panel visibility and select mode
-            ‹k›         Move selection up
-            ‹j›         Move selection down
-            ‹s›         Toggle note sorting
-            ‹↑ / ↓›     Scroll selected note content up / down
-            ‹↩ Enter›   Select the highlighted note
-
-            ‹Space›     Toggle vault selector modal
-            ‹Ctrl-u›    Scroll selected note up half a page
-            ‹Ctrl-d›    Scroll selected note down half a page
-
-  NORMAL
-          Navigate the note.
-
-          In NORMAL mode, the contents of the note can be viewed and navigated.
-          Use mouse or arrow keys ‹↑ / ↓› to scroll up / down the note. To
-          toggle the SELECT mode and show side panel, press ‹t›.
-
-            ‹q›         Quit the application
-            ‹?›         Show this help
-            ‹t›         Toggle side panel visibility and select mode
-            ‹k›         Move selection up
-            ‹j›         Move selection down
-            ‹↑ / ↓›     Scroll selected note content up / down
-            ‹↩ Enter›   Select the highlighted note
-
-            ‹Space›     Toggle vault selector modal
-            ‹Ctrl-u›    Scroll selected note up half a page
-            ‹Ctrl-d›    Scroll selected note down half a page
-
-───────────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────────
 
 KEY BINDINGS
 
+Global (available everywhere):
+
   ‹q›         Quit the application
   ‹?›         Show this help
-  ‹t›         Toggle side panel visibility and select mode
-  ‹k›         Move selection up
-  ‹j›         Move selection down
-  ‹s›         Toggle note sorting
-  ‹↑ / ↓›     Scroll selected up / down
-  ‹↩ Enter›   Select the highlighted note
+  ‹Esc›       Cancel/close modals
+  ‹Ctrl+G›    Toggle vault selector modal
 
-  ‹Space›     Toggle vault selector modal
-  ‹Ctrl-u›    Scroll up half a page
-  ‹Ctrl-d›    Scroll down half a page
+Navigation:
 
-───────────────────────────────────────────────────────────────────────────────
+  ‹Tab›       Switch between explorer and note viewer panes
+  ‹k / j›     Move selection or scroll up / down
+  ‹↑ / ↓›     Move selection or scroll up / down
+  ‹↩ Enter›   Select highlighted note (explorer only)
+
+Panel Control:
+
+  ‹t›         Toggle explorer panel visibility
+  ‹Ctrl+B›    Toggle explorer panel visibility
+  ‹s›         Toggle note sorting (explorer only)
+  ‹Ctrl+U›    Scroll up half a page
+  ‹Ctrl+D›    Scroll down half a page
+
+────────────────────────────────────────────────────────────────────────────
 
 FEATURES
 
   • Navigate and read notes from any Obsidian Vault using terminal
   • Nested folders and notes are supported
   • View markdown notes in a readable, custom styled format
+  • Toggle between focused note reading and vault exploration
+  • Sort notes alphabetically or by other criteria
 
-───────────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────────
 
 KNOWN LIMITATIONS
 
@@ -125,3 +139,4 @@ KNOWN LIMITATIONS
   • Key bindings cannot be changed with configuration
   • There is no syntax highlighting for code blocks
   • Markdown inline text styles are not rendered
+

--- a/basalt/src/help_modal.rs
+++ b/basalt/src/help_modal.rs
@@ -13,8 +13,8 @@ use ratatui::{
 pub struct HelpModalState {
     pub scrollbar_state: ScrollbarState,
     pub scrollbar_position: usize,
-    pub viewport_height: usize,
     pub text: String,
+    pub visible: bool,
 }
 
 impl HelpModalState {
@@ -26,18 +26,32 @@ impl HelpModalState {
         }
     }
 
-    pub fn scroll_up(self, amount: usize) -> Self {
+    pub fn toggle_visibility(&self) -> Self {
+        Self {
+            visible: !self.visible,
+            ..self.clone()
+        }
+    }
+
+    pub fn hide(&self) -> Self {
+        Self {
+            visible: false,
+            ..self.clone()
+        }
+    }
+
+    pub fn scroll_up(&self, amount: usize) -> Self {
         let scrollbar_position = self.scrollbar_position.saturating_sub(amount);
         let scrollbar_state = self.scrollbar_state.position(scrollbar_position);
 
         Self {
             scrollbar_state,
             scrollbar_position,
-            ..self
+            ..self.clone()
         }
     }
 
-    pub fn scroll_down(self, amount: usize) -> Self {
+    pub fn scroll_down(&self, amount: usize) -> Self {
         let scrollbar_position = self
             .scrollbar_position
             .saturating_add(amount)
@@ -48,7 +62,7 @@ impl HelpModalState {
         Self {
             scrollbar_state,
             scrollbar_position,
-            ..self
+            ..self.clone()
         }
     }
 

--- a/basalt/src/lib.rs
+++ b/basalt/src/lib.rs
@@ -2,7 +2,7 @@ pub mod app;
 pub mod explorer;
 pub mod help_modal;
 pub mod markdown;
-pub mod start;
+pub mod splash;
 pub mod statusbar;
 pub mod stylized_text;
 pub mod text_counts;

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,9 +1,7 @@
-use basalt_tui as basalt;
-
 use std::io;
 
-use basalt::app::App;
 use basalt_core::obsidian::ObsidianConfig;
+use basalt_tui::app::App;
 
 fn main() -> io::Result<()> {
     let terminal = ratatui::init();
@@ -11,6 +9,7 @@ fn main() -> io::Result<()> {
     let vaults = obsidian_config.vaults();
 
     App::start(terminal, vaults)?;
+
     ratatui::restore();
 
     Ok(())

--- a/basalt/src/markdown/state.rs
+++ b/basalt/src/markdown/state.rs
@@ -10,6 +10,7 @@ pub struct Scrollbar {
 pub struct MarkdownViewState {
     pub(crate) text: String,
     pub(crate) scrollbar: Scrollbar,
+    pub(crate) active: bool,
 }
 
 impl MarkdownViewState {
@@ -47,6 +48,13 @@ impl MarkdownViewState {
                 position: new_position,
             },
             ..self
+        }
+    }
+
+    pub fn set_active(&self, active: bool) -> Self {
+        Self {
+            active,
+            ..self.clone()
         }
     }
 

--- a/basalt/src/markdown/view.rs
+++ b/basalt/src/markdown/view.rs
@@ -328,7 +328,7 @@ impl StatefulWidgetRef for MarkdownView {
 
     fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let block = Block::bordered()
-            .border_type(BorderType::Rounded)
+            .border_type(if state.active { BorderType::Thick } else { BorderType::Rounded })
             .padding(Padding::horizontal(1));
 
         let nodes = parser::from_str(&state.text)

--- a/basalt/src/splash.rs
+++ b/basalt/src/splash.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use basalt_core::obsidian::Vault;
 use ratatui::{
     buffer::Buffer,
-    layout::{Constraint, Flex, Layout, Rect, Size},
+    layout::{Constraint, Flex, Layout, Rect},
     style::Stylize,
     text::Text,
     widgets::{StatefulWidgetRef, Widget},
@@ -42,19 +42,17 @@ pub const LOGO: [&str; 25] = [
 ];
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct StartState<'a> {
+pub struct SplashState<'a> {
     pub(crate) vault_selector_state: VaultSelectorState<'a>,
-    pub(crate) size: Size,
     pub(crate) version: &'a str,
 }
 
-impl<'a> StartState<'a> {
-    pub fn new(version: &'a str, size: Size, items: Vec<&'a Vault>) -> Self {
+impl<'a> SplashState<'a> {
+    pub fn new(version: &'a str, items: Vec<&'a Vault>) -> Self {
         let vault_selector_state = VaultSelectorState::new(items);
 
-        StartState {
+        SplashState {
             version,
-            size,
             vault_selector_state,
         }
     }
@@ -94,12 +92,12 @@ impl<'a> StartState<'a> {
 }
 
 #[derive(Default)]
-pub struct StartScreen<'a> {
+pub struct Splash<'a> {
     _lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> StatefulWidgetRef for StartScreen<'a> {
-    type State = StartState<'a>;
+impl<'a> StatefulWidgetRef for Splash<'a> {
+    type State = SplashState<'a>;
 
     fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let [_, center, _] = Layout::horizontal([

--- a/basalt/src/statusbar.rs
+++ b/basalt/src/statusbar.rs
@@ -10,17 +10,15 @@ use ratatui::{
 
 #[derive(Default, Clone, PartialEq)]
 pub struct StatusBarState<'a> {
-    mode: &'a str,
-    meta: Option<&'a str>,
+    active_component_name: &'a str,
     word_count: usize,
     char_count: usize,
 }
 
 impl<'a> StatusBarState<'a> {
-    pub fn new(mode: &'a str, meta: Option<&'a str>, word_count: usize, char_count: usize) -> Self {
+    pub fn new(active_component_name: &'a str, word_count: usize, char_count: usize) -> Self {
         Self {
-            mode,
-            meta,
+            active_component_name,
             word_count,
             char_count,
         }
@@ -40,49 +38,39 @@ impl<'a> StatefulWidgetRef for StatusBar<'a> {
             .flex(Flex::SpaceBetween)
             .areas(area);
 
-        let meta = state
-            .meta
-            .map(|meta| {
-                [
-                    Span::from(" ").bg(Color::DarkGray),
-                    Span::from(meta).bg(Color::DarkGray).gray().bold(),
-                    Span::from(" ").bg(Color::DarkGray),
-                    Span::from("").dark_gray(),
-                ]
-            })
-            .unwrap_or_default();
+        let active_component = [
+            Span::from("").dark_gray(),
+            Span::from(" ").bg(Color::DarkGray),
+            Span::from(state.active_component_name)
+                .bg(Color::DarkGray)
+                .black()
+                .bold(),
+            Span::from(" ").bg(Color::DarkGray),
+            Span::from("").dark_gray(),
+        ]
+        .to_vec();
 
-        Text::from(Line::from(
-            [
-                Span::from("").magenta(),
-                Span::from(" ").bg(Color::Magenta),
-                Span::from(state.mode).magenta().reversed().bold(),
-                Span::from(" ").bg(Color::Magenta),
-                Span::from("")
-                    .bg(if state.meta.is_some() {
-                        Color::DarkGray
-                    } else {
-                        Color::default()
-                    })
-                    .magenta(),
-            ]
-            .into_iter()
-            .chain(meta)
-            .collect::<Vec<Span>>(),
-        ))
-        .render(left, buf);
+        Text::from(Line::from(active_component)).render(left, buf);
 
         let [word_count, char_count] =
             Layout::horizontal([Constraint::Fill(1), Constraint::Fill(1)])
                 .flex(Flex::End)
                 .areas(right);
 
-        Text::from(format!("{} word{}", state.word_count, if state.word_count == 1 { "" } else { "s" }))
-            .right_aligned()
-            .render(word_count, buf);
+        Text::from(format!(
+            "{} word{}",
+            state.word_count,
+            if state.word_count == 1 { "" } else { "s" }
+        ))
+        .right_aligned()
+        .render(word_count, buf);
 
-        Text::from(format!("{} char{}", state.char_count, if state.char_count == 1 { "" } else { "s" }))
-            .right_aligned()
-            .render(char_count, buf);
+        Text::from(format!(
+            "{} char{}",
+            state.char_count,
+            if state.char_count == 1 { "" } else { "s" }
+        ))
+        .right_aligned()
+        .render(char_count, buf);
     }
 }

--- a/basalt/src/vault_selector_modal.rs
+++ b/basalt/src/vault_selector_modal.rs
@@ -12,12 +12,57 @@ use crate::vault_selector::{VaultSelector, VaultSelectorState};
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct VaultSelectorModalState<'a> {
     pub vault_selector_state: VaultSelectorState<'a>,
+    pub visible: bool,
 }
 
 impl<'a> VaultSelectorModalState<'a> {
     pub fn new(items: Vec<&'a Vault>) -> Self {
         Self {
             vault_selector_state: VaultSelectorState::new(items),
+            visible: false,
+        }
+    }
+
+    pub fn selected(&self) -> Option<usize> {
+        self.vault_selector_state.selected()
+    }
+
+    pub fn select(&self) -> Self {
+        Self {
+            vault_selector_state: self.vault_selector_state.clone().select(),
+            ..self.clone()
+        }
+    }
+
+    pub fn get_item(self, index: usize) -> Option<&'a Vault> {
+        self.vault_selector_state.get_item(index)
+    }
+
+    pub fn next(&self) -> Self {
+        Self {
+            vault_selector_state: self.vault_selector_state.clone().next(),
+            ..self.clone()
+        }
+    }
+
+    pub fn previous(&self) -> Self {
+        Self {
+            vault_selector_state: self.vault_selector_state.clone().previous(),
+            ..self.clone()
+        }
+    }
+
+    pub fn hide(&self) -> Self {
+        Self {
+            visible: false,
+            ..self.clone()
+        }
+    }
+
+    pub fn toggle_visibility(&self) -> Self {
+        Self {
+            visible: !self.visible,
+            ..self.clone()
         }
     }
 }


### PR DESCRIPTION
### [Refactor state management](https://github.com/erikjuhani/basalt/commit/65524284a30684ddca7e8c60aad8efedff71a176)

Use modules for component update and event handling isolation and
separation. This should make the code easier to reason with. Eventually
these modules will be moved into their respective files, and maybe
abstracted with a trait or something similar, but could also be kept as
is. One thing that needs to be explored is the return type of the update
functions. I think these update functions should be able to change
state, but also to delegate additional events or commands. I believe
this is also called 'effects pattern'.

The 'Action's were renamed to 'Message's to match the terminology of
Elm Architecture more precisely. The Message modal is a collection of
'Global' messages and dedicated component messages. This ensures that
the top level message can be used ergonomically to update the complete
App state, since often one component can modify other component or the
global app state.

Additionally, I added more keybindings to help with navigation. For
example ESC can now be used to close modals, and arrow keys can be used
to navigate notes. The new keybindings are captured in the help.txt
file.

The modes (SELECT, NORMAL) were completely removed as obsolete and now
the status bar no longer shows the filename or mode, but instead it
shows the currently active pane.

Start widget was renamed to Splash widget.