### PR TITLE
Remove Screen state enum and use one AppState instead

### DIFF
--- a/basalt/src/lib.rs
+++ b/basalt/src/lib.rs
@@ -4,7 +4,7 @@ pub mod explorer;
 pub mod help_modal;
 pub mod note_editor;
 pub mod outline;
-pub mod splash;
+pub mod splash_modal;
 pub mod statusbar;
 pub mod stylized_text;
 pub mod text_counts;

--- a/basalt/src/splash_modal.rs
+++ b/basalt/src/splash_modal.rs
@@ -6,7 +6,7 @@ use ratatui::{
     layout::{Constraint, Flex, Layout, Rect},
     style::Stylize,
     text::Text,
-    widgets::{StatefulWidgetRef, Widget},
+    widgets::{Clear, StatefulWidgetRef, Widget},
 };
 
 use crate::vault_selector::{VaultSelector, VaultSelectorState};
@@ -42,18 +42,20 @@ pub const LOGO: [&str; 25] = [
 ];
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct SplashState<'a> {
+pub struct SplashModalState<'a> {
     pub(crate) vault_selector_state: VaultSelectorState<'a>,
     pub(crate) version: &'a str,
+    pub(crate) visible: bool,
 }
 
-impl<'a> SplashState<'a> {
-    pub fn new(version: &'a str, items: Vec<&'a Vault>) -> Self {
+impl<'a> SplashModalState<'a> {
+    pub fn new(version: &'a str, items: Vec<&'a Vault>, visible: bool) -> Self {
         let vault_selector_state = VaultSelectorState::new(items);
 
-        SplashState {
+        SplashModalState {
             version,
             vault_selector_state,
+            visible,
         }
     }
 
@@ -92,14 +94,16 @@ impl<'a> SplashState<'a> {
 }
 
 #[derive(Default)]
-pub struct Splash<'a> {
+pub struct SplashModal<'a> {
     _lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> StatefulWidgetRef for Splash<'a> {
-    type State = SplashState<'a>;
+impl<'a> StatefulWidgetRef for SplashModal<'a> {
+    type State = SplashModalState<'a>;
 
     fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        Clear.render(area, buf);
+
         let [_, center, _] = Layout::horizontal([
             Constraint::Fill(1),
             Constraint::Length(79),


### PR DESCRIPTION
I converged AppState with MainState and removed the screen abstraction to make state management simpler. The splash is now displayed as a "Modal" instead, which will make way for allowing workflows where splash is never displayed.