### PR TITLE
Add arbitrary command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Each key mapping is associated with a specific 'pane' and becomes active when th
 # quit: exits the application
 # vault_selector_modal_toggle: toggles vault selector modal (not available in splash screen)
 # help_modal_toggle: toggles help modal
+# spawn: <command> spawns a new process without blocking. This is for opening external applications or URLs.
+# exec: <command> runs a command in the current shell environment.
 #
 # Splash commands:
 #
@@ -145,6 +147,8 @@ key_bindings = [
  { key = "q", command = "quit" },
  { key = "ctrl+g", command = "vault_selector_modal_toggle" },
  { key = "?", command = "help_modal_toggle" },
+ { key = "ctrl+alt+e", command = "exec:vi %note_path" },
+ { key = "ctrl+alt+o", command = "spawn:open obsidian://open?vault=%vault&file=%note" },
 ]
 
 [splash]

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.10.1 (Unreleased)
+## 0.10.1 (2025-08-31)
+
+### Added
+
+- [Add arbitrary (sync, spawn) command execution](https://github.com/erikjuhani/basalt/commit/750108f3282af5e947c23eb88ff3b5f8f196d0e4)
 
 ### Changed
 

--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -6,6 +6,8 @@
 # quit: exits the application
 # vault_selector_modal_toggle: toggles vault selector modal (not available in splash screen)
 # help_modal_toggle: toggles help modal
+# spawn: <command> spawns a new process without blocking. This is for opening external applications or URLs.
+# exec: <command> runs a command in the current shell environment.
 #
 # Splash commands:
 #
@@ -75,6 +77,8 @@ key_bindings = [
  { key = "q", command = "quit" },
  { key = "ctrl+g", command = "vault_selector_modal_toggle" },
  { key = "?", command = "help_modal_toggle" },
+ { key = "ctrl+alt+e", command = "exec:vi %note_path" },
+ { key = "ctrl+alt+o", command = "spawn:open obsidian://open?vault=%vault&file=%note" },
 ]
 
 [splash]

--- a/basalt/src/command.rs
+++ b/basalt/src/command.rs
@@ -1,0 +1,394 @@
+use ratatui::{
+    crossterm::{
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+        ExecutableCommand,
+    },
+    DefaultTerminal,
+};
+use serde::{Deserialize, Deserializer};
+use std::{io::stdout, process};
+
+use crate::{
+    app::{Message, ScrollAmount},
+    explorer, help_modal, note_editor, outline, splash_modal, vault_selector_modal,
+};
+
+trait ReplaceVar {
+    fn replace_var(&self, variable: &str, content: &str) -> Self;
+}
+
+impl ReplaceVar for String {
+    fn replace_var(&self, variable: &str, content: &str) -> Self {
+        self.replace(variable, content)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Command {
+    Quit,
+
+    SplashUp,
+    SplashDown,
+    SplashOpen,
+
+    ExplorerUp,
+    ExplorerDown,
+    ExplorerOpen,
+    ExplorerSort,
+    ExplorerToggle,
+    ExplorerToggleOutline,
+    ExplorerSwitchPaneNext,
+    ExplorerSwitchPanePrevious,
+    ExplorerScrollUpOne,
+    ExplorerScrollDownOne,
+    ExplorerScrollUpHalfPage,
+    ExplorerScrollDownHalfPage,
+
+    OutlineUp,
+    OutlineDown,
+    OutlineSelect,
+    OutlineExpand,
+    OutlineToggle,
+    OutlineToggleExplorer,
+    OutlineSwitchPaneNext,
+    OutlineSwitchPanePrevious,
+
+    HelpModalScrollUpOne,
+    HelpModalScrollDownOne,
+    HelpModalScrollUpHalfPage,
+    HelpModalScrollDownHalfPage,
+    HelpModalToggle,
+    HelpModalClose,
+
+    NoteEditorScrollUpOne,
+    NoteEditorScrollDownOne,
+    NoteEditorScrollUpHalfPage,
+    NoteEditorScrollDownHalfPage,
+    NoteEditorSwitchPaneNext,
+    NoteEditorSwitchPanePrevious,
+    NoteEditorToggleExplorer,
+    NoteEditorToggleOutline,
+    NoteEditorCursorUp,
+    NoteEditorCursorDown,
+
+    // # Experimental editor
+    NoteEditorExperimentalCursorWordForward,
+    NoteEditorExperimentalCursorWordBackward,
+    NoteEditorExperimentalSetEditMode,
+    NoteEditorExperimentalSetReadMode,
+    NoteEditorExperimentalSave,
+    NoteEditorExperimentalExitMode,
+    NoteEditorExperimentalCursorLeft,
+    NoteEditorExperimentalCursorRight,
+
+    VaultSelectorModalUp,
+    VaultSelectorModalDown,
+    VaultSelectorModalClose,
+    VaultSelectorModalOpen,
+    VaultSelectorModalToggle,
+
+    Exec(String),
+    Spawn(String),
+}
+
+fn str_to_command(s: &str) -> Option<Command> {
+    match s {
+        "quit" => Some(Command::Quit),
+
+        "splash_up" => Some(Command::SplashUp),
+        "splash_down" => Some(Command::SplashDown),
+        "splash_open" => Some(Command::SplashOpen),
+
+        "explorer_up" => Some(Command::ExplorerUp),
+        "explorer_down" => Some(Command::ExplorerDown),
+        "explorer_open" => Some(Command::ExplorerOpen),
+        "explorer_sort" => Some(Command::ExplorerSort),
+        "explorer_toggle" => Some(Command::ExplorerToggle),
+        "explorer_toggle_outline" => Some(Command::ExplorerToggleOutline),
+        "explorer_switch_pane_next" => Some(Command::ExplorerSwitchPaneNext),
+        "explorer_switch_pane_previous" => Some(Command::ExplorerSwitchPanePrevious),
+        "explorer_scroll_up_one" => Some(Command::ExplorerScrollUpOne),
+        "explorer_scroll_down_one" => Some(Command::ExplorerScrollDownOne),
+        "explorer_scroll_up_half_page" => Some(Command::ExplorerScrollUpHalfPage),
+        "explorer_scroll_down_half_page" => Some(Command::ExplorerScrollDownHalfPage),
+
+        "outline_up" => Some(Command::OutlineUp),
+        "outline_down" => Some(Command::OutlineDown),
+        "outline_select" => Some(Command::OutlineSelect),
+        "outline_expand" => Some(Command::OutlineExpand),
+        "outline_toggle" => Some(Command::OutlineToggle),
+        "outline_toggle_explorer" => Some(Command::OutlineToggleExplorer),
+        "outline_switch_pane_next" => Some(Command::OutlineSwitchPaneNext),
+        "outline_switch_pane_previous" => Some(Command::OutlineSwitchPanePrevious),
+
+        "help_modal_scroll_up_one" => Some(Command::HelpModalScrollUpOne),
+        "help_modal_scroll_down_one" => Some(Command::HelpModalScrollDownOne),
+        "help_modal_scroll_up_half_page" => Some(Command::HelpModalScrollUpHalfPage),
+        "help_modal_scroll_down_half_page" => Some(Command::HelpModalScrollDownHalfPage),
+        "help_modal_toggle" => Some(Command::HelpModalToggle),
+        "help_modal_close" => Some(Command::HelpModalClose),
+
+        "note_editor_scroll_up_one" => Some(Command::NoteEditorScrollUpOne),
+        "note_editor_scroll_down_one" => Some(Command::NoteEditorScrollDownOne),
+        "note_editor_scroll_up_half_page" => Some(Command::NoteEditorScrollUpHalfPage),
+        "note_editor_scroll_down_half_page" => Some(Command::NoteEditorScrollDownHalfPage),
+        "note_editor_switch_pane_next" => Some(Command::NoteEditorSwitchPaneNext),
+        "note_editor_switch_pane_previous" => Some(Command::NoteEditorSwitchPanePrevious),
+        "note_editor_toggle_explorer" => Some(Command::NoteEditorToggleExplorer),
+        "note_editor_toggle_outline" => Some(Command::NoteEditorToggleOutline),
+        "note_editor_cursor_up" => Some(Command::NoteEditorCursorUp),
+        "note_editor_cursor_down" => Some(Command::NoteEditorCursorDown),
+
+        "note_editor_experimental_cursor_word_forward" => {
+            Some(Command::NoteEditorExperimentalCursorWordForward)
+        }
+        "note_editor_experimental_cursor_word_backward" => {
+            Some(Command::NoteEditorExperimentalCursorWordBackward)
+        }
+        "note_editor_experimental_set_edit_mode" => {
+            Some(Command::NoteEditorExperimentalSetEditMode)
+        }
+        "note_editor_experimental_set_read_mode" => {
+            Some(Command::NoteEditorExperimentalSetReadMode)
+        }
+        "note_editor_experimental_save" => Some(Command::NoteEditorExperimentalSave),
+        "note_editor_experimental_exit_mode" => Some(Command::NoteEditorExperimentalExitMode),
+        "note_editor_experimental_cursor_left" => Some(Command::NoteEditorExperimentalCursorLeft),
+        "note_editor_experimental_cursor_right" => Some(Command::NoteEditorExperimentalCursorRight),
+
+        "vault_selector_modal_up" => Some(Command::VaultSelectorModalUp),
+        "vault_selector_modal_down" => Some(Command::VaultSelectorModalDown),
+        "vault_selector_modal_close" => Some(Command::VaultSelectorModalClose),
+        "vault_selector_modal_open" => Some(Command::VaultSelectorModalOpen),
+        "vault_selector_modal_toggle" => Some(Command::VaultSelectorModalToggle),
+
+        _ => None,
+    }
+}
+
+impl<'de> Deserialize<'de> for Command {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        if let Some(command) = s
+            .strip_prefix("exec:")
+            .map(|command| Command::Exec(command.to_string()))
+            .or(s
+                .strip_prefix("spawn:")
+                .map(|command| Command::Spawn(command.to_string())))
+        {
+            return Ok(command);
+        }
+
+        str_to_command(&s).ok_or(serde::de::Error::custom(format!(
+            "{s} is not a valid command"
+        )))
+    }
+}
+
+impl From<Command> for Message<'_> {
+    fn from(value: Command) -> Self {
+        match value {
+            Command::Quit => Message::Quit,
+
+            Command::SplashUp => Message::Splash(splash_modal::Message::Up),
+            Command::SplashDown => Message::Splash(splash_modal::Message::Down),
+            Command::SplashOpen => Message::Splash(splash_modal::Message::Open),
+
+            Command::ExplorerUp => Message::Explorer(explorer::Message::Up),
+            Command::ExplorerDown => Message::Explorer(explorer::Message::Down),
+            Command::ExplorerOpen => Message::Explorer(explorer::Message::Open),
+            Command::ExplorerSort => Message::Explorer(explorer::Message::Sort),
+            Command::ExplorerToggle => Message::Explorer(explorer::Message::Toggle),
+            Command::ExplorerToggleOutline => Message::Explorer(explorer::Message::ToggleOutline),
+            Command::ExplorerSwitchPaneNext => Message::Explorer(explorer::Message::SwitchPaneNext),
+            Command::ExplorerSwitchPanePrevious => {
+                Message::Explorer(explorer::Message::SwitchPanePrevious)
+            }
+            Command::ExplorerScrollUpOne => {
+                Message::Explorer(explorer::Message::ScrollUp(ScrollAmount::One))
+            }
+            Command::ExplorerScrollDownOne => {
+                Message::Explorer(explorer::Message::ScrollDown(ScrollAmount::One))
+            }
+            Command::ExplorerScrollUpHalfPage => {
+                Message::Explorer(explorer::Message::ScrollUp(ScrollAmount::HalfPage))
+            }
+            Command::ExplorerScrollDownHalfPage => {
+                Message::Explorer(explorer::Message::ScrollDown(ScrollAmount::HalfPage))
+            }
+
+            Command::OutlineUp => Message::Outline(outline::Message::Up),
+            Command::OutlineDown => Message::Outline(outline::Message::Down),
+            Command::OutlineSelect => Message::Outline(outline::Message::Select),
+            Command::OutlineExpand => Message::Outline(outline::Message::Expand),
+            Command::OutlineToggle => Message::Outline(outline::Message::Toggle),
+            Command::OutlineToggleExplorer => Message::Outline(outline::Message::ToggleExplorer),
+            Command::OutlineSwitchPaneNext => Message::Outline(outline::Message::SwitchPaneNext),
+            Command::OutlineSwitchPanePrevious => {
+                Message::Outline(outline::Message::SwitchPanePrevious)
+            }
+
+            Command::HelpModalScrollUpOne => {
+                Message::HelpModal(help_modal::Message::ScrollUp(ScrollAmount::One))
+            }
+            Command::HelpModalScrollDownOne => {
+                Message::HelpModal(help_modal::Message::ScrollDown(ScrollAmount::One))
+            }
+            Command::HelpModalScrollUpHalfPage => {
+                Message::HelpModal(help_modal::Message::ScrollUp(ScrollAmount::HalfPage))
+            }
+            Command::HelpModalScrollDownHalfPage => {
+                Message::HelpModal(help_modal::Message::ScrollDown(ScrollAmount::HalfPage))
+            }
+            Command::HelpModalToggle => Message::HelpModal(help_modal::Message::Toggle),
+            Command::HelpModalClose => Message::HelpModal(help_modal::Message::Close),
+
+            Command::NoteEditorScrollUpOne => {
+                Message::NoteEditor(note_editor::Message::ScrollUp(ScrollAmount::One))
+            }
+            Command::NoteEditorScrollDownOne => {
+                Message::NoteEditor(note_editor::Message::ScrollDown(ScrollAmount::One))
+            }
+            Command::NoteEditorScrollUpHalfPage => {
+                Message::NoteEditor(note_editor::Message::ScrollUp(ScrollAmount::HalfPage))
+            }
+            Command::NoteEditorScrollDownHalfPage => {
+                Message::NoteEditor(note_editor::Message::ScrollDown(ScrollAmount::HalfPage))
+            }
+            Command::NoteEditorSwitchPaneNext => {
+                Message::NoteEditor(note_editor::Message::SwitchPaneNext)
+            }
+            Command::NoteEditorSwitchPanePrevious => {
+                Message::NoteEditor(note_editor::Message::SwitchPanePrevious)
+            }
+            Command::NoteEditorCursorUp => Message::NoteEditor(note_editor::Message::CursorUp),
+            Command::NoteEditorCursorDown => Message::NoteEditor(note_editor::Message::CursorDown),
+            Command::NoteEditorToggleExplorer => {
+                Message::NoteEditor(note_editor::Message::ToggleExplorer)
+            }
+            Command::NoteEditorToggleOutline => {
+                Message::NoteEditor(note_editor::Message::ToggleOutline)
+            }
+            // Experimental
+            Command::NoteEditorExperimentalSetEditMode => {
+                Message::NoteEditor(note_editor::Message::EditMode)
+            }
+            Command::NoteEditorExperimentalSetReadMode => {
+                Message::NoteEditor(note_editor::Message::ReadMode)
+            }
+            Command::NoteEditorExperimentalSave => Message::NoteEditor(note_editor::Message::Save),
+            Command::NoteEditorExperimentalExitMode => {
+                Message::NoteEditor(note_editor::Message::ExitMode)
+            }
+            Command::NoteEditorExperimentalCursorWordForward => {
+                Message::NoteEditor(note_editor::Message::CursorWordForward)
+            }
+            Command::NoteEditorExperimentalCursorWordBackward => {
+                Message::NoteEditor(note_editor::Message::CursorWordBackward)
+            }
+            Command::NoteEditorExperimentalCursorLeft => {
+                Message::NoteEditor(note_editor::Message::CursorLeft)
+            }
+            Command::NoteEditorExperimentalCursorRight => {
+                Message::NoteEditor(note_editor::Message::CursorRight)
+            }
+            Command::VaultSelectorModalClose => {
+                Message::VaultSelectorModal(vault_selector_modal::Message::Close)
+            }
+            Command::VaultSelectorModalToggle => {
+                Message::VaultSelectorModal(vault_selector_modal::Message::Toggle)
+            }
+            Command::VaultSelectorModalUp => {
+                Message::VaultSelectorModal(vault_selector_modal::Message::Up)
+            }
+            Command::VaultSelectorModalDown => {
+                Message::VaultSelectorModal(vault_selector_modal::Message::Down)
+            }
+            Command::VaultSelectorModalOpen => {
+                Message::VaultSelectorModal(vault_selector_modal::Message::Select)
+            }
+            Command::Exec(command) => Message::Exec(command),
+            Command::Spawn(command) => Message::Spawn(command),
+        }
+    }
+}
+
+pub fn run_command<'a>(
+    command: String,
+    vault_name: &str,
+    note_name: &str,
+    note_path: &str,
+    mut callback: impl FnMut(&str, &[&str]) -> Option<Message<'a>>,
+) -> Option<Message<'a>> {
+    let expanded = command
+        .replace_var("%vault", vault_name)
+        // Order matters, otherwise all mentions of %note_path would be replaced with %note value
+        .replace_var("%note_path", note_path)
+        .replace_var("%note", note_name);
+
+    let args = expanded.split_whitespace().collect::<Vec<_>>();
+
+    match args.as_slice() {
+        [command, args @ ..] => callback(command, args),
+        [] => None,
+    }
+}
+
+pub fn sync_command<'a>(
+    terminal: &mut DefaultTerminal,
+    command: String,
+    vault_name: &str,
+    note_name: &str,
+    note_path: &str,
+) -> Option<Message<'a>> {
+    fn enter_alternate_screen(terminal: &mut DefaultTerminal) -> Result<(), std::io::Error> {
+        disable_raw_mode()?;
+        stdout().execute(LeaveAlternateScreen)?;
+        stdout().execute(EnterAlternateScreen)?;
+        enable_raw_mode()?;
+        terminal.clear()
+    }
+
+    run_command(
+        command,
+        vault_name,
+        note_name,
+        note_path,
+        |command, args| {
+            // TODO:Error handling
+            process::Command::new(command)
+                .arg(args.join(" "))
+                .status()
+                .ok()?;
+            enter_alternate_screen(terminal)
+                .map(|_| Message::Explorer(explorer::Message::Open))
+                .ok()
+        },
+    )
+}
+
+pub fn spawn_command<'a>(
+    command: String,
+    vault_name: &str,
+    note_name: &str,
+    note_path: &str,
+) -> Option<Message<'a>> {
+    run_command(
+        command,
+        vault_name,
+        note_name,
+        note_path,
+        |command, args| {
+            // TODO:Error handling
+            _ = process::Command::new(command)
+                .arg(args.join(" "))
+                .spawn()
+                .ok();
+            None
+        },
+    )
+}

--- a/basalt/src/config.rs
+++ b/basalt/src/config.rs
@@ -4,10 +4,10 @@ use core::fmt;
 use std::{collections::BTreeMap, fs::read_to_string};
 
 use etcetera::{choose_base_strategy, home_dir, BaseStrategy};
-use key_binding::{Command, KeyBinding};
+use key_binding::KeyBinding;
 use serde::Deserialize;
 
-use crate::app::Message;
+use crate::{app::Message, command::Command};
 pub(crate) use key_binding::Key;
 
 #[derive(Debug, thiserror::Error)]
@@ -278,7 +278,7 @@ mod tests {
 
     #[test]
     fn test_config() {
-        use key_binding::{Command, Key};
+        use key_binding::Key;
 
         let dummy_toml = r#"
         [global]

--- a/basalt/src/config/key_binding.rs
+++ b/basalt/src/config/key_binding.rs
@@ -7,11 +7,7 @@ use serde::{
     Deserialize, Deserializer,
 };
 
-use crate::{
-    app::{Message, ScrollAmount},
-    explorer, help_modal, outline, splash_modal, vault_selector_modal,
-};
-use crate::{config::ConfigError, note_editor};
+use crate::{command::Command, config::ConfigError};
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub(crate) struct KeyBinding {
@@ -129,6 +125,7 @@ fn parse_modifiers(modifiers: &str) -> Result<KeyModifiers, ConfigError> {
         _ => Err(ConfigError::UnknownKeyModifiers(modifiers.to_string())),
     }
 }
+
 fn parse_code(code: &str) -> Result<KeyCode, ConfigError> {
     match code.len() {
         0 => Some(KeyCode::Null),
@@ -173,198 +170,6 @@ impl From<&KeyEvent> for Key {
         Self {
             code: event.code,
             modifiers: event.modifiers,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum Command {
-    Quit,
-
-    SplashUp,
-    SplashDown,
-    SplashOpen,
-
-    ExplorerUp,
-    ExplorerDown,
-    ExplorerOpen,
-    ExplorerSort,
-    ExplorerToggle,
-    ExplorerToggleOutline,
-    ExplorerSwitchPaneNext,
-    ExplorerSwitchPanePrevious,
-    ExplorerScrollUpOne,
-    ExplorerScrollDownOne,
-    ExplorerScrollUpHalfPage,
-    ExplorerScrollDownHalfPage,
-
-    OutlineUp,
-    OutlineDown,
-    OutlineSelect,
-    OutlineExpand,
-    OutlineToggle,
-    OutlineToggleExplorer,
-    OutlineSwitchPaneNext,
-    OutlineSwitchPanePrevious,
-
-    HelpModalScrollUpOne,
-    HelpModalScrollDownOne,
-    HelpModalScrollUpHalfPage,
-    HelpModalScrollDownHalfPage,
-    HelpModalToggle,
-    HelpModalClose,
-
-    NoteEditorScrollUpOne,
-    NoteEditorScrollDownOne,
-    NoteEditorScrollUpHalfPage,
-    NoteEditorScrollDownHalfPage,
-    NoteEditorSwitchPaneNext,
-    NoteEditorSwitchPanePrevious,
-    NoteEditorToggleExplorer,
-    NoteEditorToggleOutline,
-    NoteEditorCursorUp,
-    NoteEditorCursorDown,
-
-    // # Experimental editor
-    NoteEditorExperimentalCursorWordForward,
-    NoteEditorExperimentalCursorWordBackward,
-    NoteEditorExperimentalSetEditMode,
-    NoteEditorExperimentalSetReadMode,
-    NoteEditorExperimentalSave,
-    NoteEditorExperimentalExitMode,
-    NoteEditorExperimentalCursorLeft,
-    NoteEditorExperimentalCursorRight,
-
-    VaultSelectorModalUp,
-    VaultSelectorModalDown,
-    VaultSelectorModalClose,
-    VaultSelectorModalOpen,
-    VaultSelectorModalToggle,
-}
-
-impl From<Command> for Message<'_> {
-    fn from(value: Command) -> Self {
-        match value {
-            Command::Quit => Message::Quit,
-
-            Command::SplashUp => Message::Splash(splash_modal::Message::Up),
-            Command::SplashDown => Message::Splash(splash_modal::Message::Down),
-            Command::SplashOpen => Message::Splash(splash_modal::Message::Open),
-
-            Command::ExplorerUp => Message::Explorer(explorer::Message::Up),
-            Command::ExplorerDown => Message::Explorer(explorer::Message::Down),
-            Command::ExplorerOpen => Message::Explorer(explorer::Message::Open),
-            Command::ExplorerSort => Message::Explorer(explorer::Message::Sort),
-            Command::ExplorerToggle => Message::Explorer(explorer::Message::Toggle),
-            Command::ExplorerToggleOutline => Message::Explorer(explorer::Message::ToggleOutline),
-            Command::ExplorerSwitchPaneNext => Message::Explorer(explorer::Message::SwitchPaneNext),
-            Command::ExplorerSwitchPanePrevious => {
-                Message::Explorer(explorer::Message::SwitchPanePrevious)
-            }
-            Command::ExplorerScrollUpOne => {
-                Message::Explorer(explorer::Message::ScrollUp(ScrollAmount::One))
-            }
-            Command::ExplorerScrollDownOne => {
-                Message::Explorer(explorer::Message::ScrollDown(ScrollAmount::One))
-            }
-            Command::ExplorerScrollUpHalfPage => {
-                Message::Explorer(explorer::Message::ScrollUp(ScrollAmount::HalfPage))
-            }
-            Command::ExplorerScrollDownHalfPage => {
-                Message::Explorer(explorer::Message::ScrollDown(ScrollAmount::HalfPage))
-            }
-
-            Command::OutlineUp => Message::Outline(outline::Message::Up),
-            Command::OutlineDown => Message::Outline(outline::Message::Down),
-            Command::OutlineSelect => Message::Outline(outline::Message::Select),
-            Command::OutlineExpand => Message::Outline(outline::Message::Expand),
-            Command::OutlineToggle => Message::Outline(outline::Message::Toggle),
-            Command::OutlineToggleExplorer => Message::Outline(outline::Message::ToggleExplorer),
-            Command::OutlineSwitchPaneNext => Message::Outline(outline::Message::SwitchPaneNext),
-            Command::OutlineSwitchPanePrevious => {
-                Message::Outline(outline::Message::SwitchPanePrevious)
-            }
-
-            Command::HelpModalScrollUpOne => {
-                Message::HelpModal(help_modal::Message::ScrollUp(ScrollAmount::One))
-            }
-            Command::HelpModalScrollDownOne => {
-                Message::HelpModal(help_modal::Message::ScrollDown(ScrollAmount::One))
-            }
-            Command::HelpModalScrollUpHalfPage => {
-                Message::HelpModal(help_modal::Message::ScrollUp(ScrollAmount::HalfPage))
-            }
-            Command::HelpModalScrollDownHalfPage => {
-                Message::HelpModal(help_modal::Message::ScrollDown(ScrollAmount::HalfPage))
-            }
-            Command::HelpModalToggle => Message::HelpModal(help_modal::Message::Toggle),
-            Command::HelpModalClose => Message::HelpModal(help_modal::Message::Close),
-
-            Command::NoteEditorScrollUpOne => {
-                Message::NoteEditor(note_editor::Message::ScrollUp(ScrollAmount::One))
-            }
-            Command::NoteEditorScrollDownOne => {
-                Message::NoteEditor(note_editor::Message::ScrollDown(ScrollAmount::One))
-            }
-            Command::NoteEditorScrollUpHalfPage => {
-                Message::NoteEditor(note_editor::Message::ScrollUp(ScrollAmount::HalfPage))
-            }
-            Command::NoteEditorScrollDownHalfPage => {
-                Message::NoteEditor(note_editor::Message::ScrollDown(ScrollAmount::HalfPage))
-            }
-            Command::NoteEditorSwitchPaneNext => {
-                Message::NoteEditor(note_editor::Message::SwitchPaneNext)
-            }
-            Command::NoteEditorSwitchPanePrevious => {
-                Message::NoteEditor(note_editor::Message::SwitchPanePrevious)
-            }
-            Command::NoteEditorCursorUp => Message::NoteEditor(note_editor::Message::CursorUp),
-            Command::NoteEditorCursorDown => Message::NoteEditor(note_editor::Message::CursorDown),
-            Command::NoteEditorToggleExplorer => {
-                Message::NoteEditor(note_editor::Message::ToggleExplorer)
-            }
-            Command::NoteEditorToggleOutline => {
-                Message::NoteEditor(note_editor::Message::ToggleOutline)
-            }
-            // Experimental
-            Command::NoteEditorExperimentalSetEditMode => {
-                Message::NoteEditor(note_editor::Message::EditMode)
-            }
-            Command::NoteEditorExperimentalSetReadMode => {
-                Message::NoteEditor(note_editor::Message::ReadMode)
-            }
-            Command::NoteEditorExperimentalSave => Message::NoteEditor(note_editor::Message::Save),
-            Command::NoteEditorExperimentalExitMode => {
-                Message::NoteEditor(note_editor::Message::ExitMode)
-            }
-            Command::NoteEditorExperimentalCursorWordForward => {
-                Message::NoteEditor(note_editor::Message::CursorWordForward)
-            }
-            Command::NoteEditorExperimentalCursorWordBackward => {
-                Message::NoteEditor(note_editor::Message::CursorWordBackward)
-            }
-            Command::NoteEditorExperimentalCursorLeft => {
-                Message::NoteEditor(note_editor::Message::CursorLeft)
-            }
-            Command::NoteEditorExperimentalCursorRight => {
-                Message::NoteEditor(note_editor::Message::CursorRight)
-            }
-            Command::VaultSelectorModalClose => {
-                Message::VaultSelectorModal(vault_selector_modal::Message::Close)
-            }
-            Command::VaultSelectorModalToggle => {
-                Message::VaultSelectorModal(vault_selector_modal::Message::Toggle)
-            }
-            Command::VaultSelectorModalUp => {
-                Message::VaultSelectorModal(vault_selector_modal::Message::Up)
-            }
-            Command::VaultSelectorModalDown => {
-                Message::VaultSelectorModal(vault_selector_modal::Message::Down)
-            }
-            Command::VaultSelectorModalOpen => {
-                Message::VaultSelectorModal(vault_selector_modal::Message::Select)
-            }
         }
     }
 }

--- a/basalt/src/lib.rs
+++ b/basalt/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod command;
 pub mod config;
 pub mod explorer;
 pub mod help_modal;

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -128,7 +128,7 @@ impl Editor<'_> {
                             line,
                             // We subtract two to take the whitespace into account, which are
                             // added in the format string.
-                            (line.chars().count()..width - 2)
+                            (line.chars().count()..width.saturating_sub(2))
                                 .map(|_| " ")
                                 .collect::<String>()
                         )

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -22,6 +22,153 @@ Basalt key mappings can be modified or extended by defining key mappings in the 
 
 Each key mapping is associated with a specific 'pane' and becomes active when that pane has focus. The global section applies to all panes and is evaluated first.
 
+Key bindings support both built-in Basalt commands and custom arbitrary command execution, allowing you to integrate external applications and create automation workflows.
+
+## Custom Command Execution
+
+In addition to built-in commands, you can execute arbitrary external commands using special command prefixes:
+
+```toml
+[global]
+key_bindings = [
+  { key = "q", command = "quit" },  # Built-in command
+  { key = "ctrl+alt+e", command = "spawn:open obsidian://daily?vault=%vault" },  # Custom spawn command
+  { key = "ctrl+g", command = "exec:nvim %note" },  # Custom exec command
+]
+```
+
+### Command Types
+
+#### Built-in Commands
+
+These are Basalt's native commands that control application behavior (see full list in the Default Configuration section below).
+
+#### Execute Command - `exec:`
+
+Runs a command in the current shell environment. The command will block until completion. Only the first argument is treated as the executable command, with all remaining arguments passed as literal parameters.
+
+```toml
+key_bindings = [
+  { key = "ctrl+alt+e", command = "exec:nvim %note_path" },
+]
+```
+
+#### Spawn Process - `spawn:`
+
+Spawns a new process without blocking. This is for opening external applications or URLs. Like `exec:`, only the first argument is the executable, with remaining arguments passed as literal parameters.
+
+```toml
+key_bindings = [
+  { key = "ctrl+o", command = "spawn:open %note" },
+  { key = "ctrl+b", command = "spawn:open https://example.com" },
+]
+```
+
+## Variables
+
+Basalt provides special variables that are dynamically replaced with current context information:
+
+| Variable | Description | Example Value |
+|----------|-------------|---------------|
+| `%vault` | Current vault name | `my-notes` |
+| `%note` | Current note name | `My Note` |
+| `%note_path` | Current note file path | `/path/to/vault/daily/2024-01-15.md` |
+
+Variables can be used anywhere within the command string and will be replaced at runtime.
+
+## Integration Examples
+
+### Obsidian Integration
+
+Obsidian supports URL schemes that start with `obsidian://`, allowing you to trigger various actions within the application:
+
+```toml
+# Open daily note in Obsidian
+key_bindings = [
+  { key = "ctrl+d", command = "spawn:open obsidian://daily?vault=%vault" },
+]
+
+# Open specific note in Obsidian
+key_bindings = [
+  { key = "ctrl+alt+e", command = "spawn:open obsidian://open?vault=%vault&file=%note" },
+]
+
+# Create new note in Obsidian
+key_bindings = [
+  { key = "ctrl+n", command = "spawn:open obsidian://new?vault=%vault&name=New Note" },
+]
+
+# Open specific path in Obsidian
+key_bindings = [
+  { key = "ctrl+p", command = "spawn:open obsidian://open?path=%note_path" },
+]
+```
+
+Common Obsidian URI actions include:
+- `obsidian://open` - Open a specific note
+- `obsidian://new` - Create a new note
+- `obsidian://daily` - Open daily note
+- `obsidian://search` - Perform a search
+
+For more information about Obsidian URI schemes, see the [official Obsidian URI documentation](https://help.obsidian.md/Extending+Obsidian/Obsidian+URI).
+
+### External Editor Integration
+
+```toml
+# Open current note in VS Code
+key_bindings = [
+  { key = "ctrl+c", command = "spawn:code %note" },
+]
+
+# Open current note in vim
+key_bindings = [
+  { key = "ctrl+v", command = "exec:vim %note" },
+]
+
+# Open current note in nano
+key_bindings = [
+  { key = "ctrl+n", command = "exec:nano %note" },
+]
+```
+
+### Web Integration
+
+```toml
+# Open specific URLs
+key_bindings = [
+  { key = "ctrl+g", command = "spawn:open https://github.com/user/repo" },
+]
+
+# Search engines - construct URLs with variables
+key_bindings = [
+  { key = "ctrl+s", command = "spawn:open https://www.google.com/search?q=%note" },
+]
+```
+
+## Platform Considerations
+
+- **macOS**: Use `cmd` instead of `ctrl` for standard shortcuts, and `open` command for launching applications
+- **Linux**: Use `xdg-open` for opening files/URLs with default applications
+- **Windows**: Use `start` command for opening files/URLs
+
+## Tips
+
+1. **Use `spawn:` for non-blocking operations** like opening applications or URLs
+2. **Use `exec:` for quick commands** that should complete before continuing
+3. **Test your key bindings** to ensure they don't conflict with existing Basalt shortcuts
+4. **Command limitations** - only the first argument is the executable, no shell expansion or piping
+5. **Use full paths** if executables aren't in your PATH
+6. **Variables work in arguments** - `%vault`, `%note` and `%note_path` are expanded in argument positions
+
+## Troubleshooting
+
+- If a key binding doesn't work, check that the key combination isn't already used by Basalt or your system
+- Ensure external commands are available in your PATH
+- Use absolute paths for commands if they're not found
+- Check that variables like `%vault`, `%note` and `%note_path` are being populated correctly in your context
+- Shell features like pipes (`|`), redirects (`>`), and command substitution (`$(...)`) are not supported
+- Complex operations requiring shell features should be wrapped in scripts that can be called as single commands
+
 ## Default configuration
 
 ```toml
@@ -33,6 +180,8 @@ Each key mapping is associated with a specific 'pane' and becomes active when th
 # quit: exits the application
 # vault_selector_modal_toggle: toggles vault selector modal (not available in splash screen)
 # help_modal_toggle: toggles help modal
+# spawn: <command> spawns a new process without blocking. This is for opening external applications or URLs.
+# exec: <command> runs a command in the current shell environment.
 #
 # Splash commands:
 #
@@ -102,6 +251,8 @@ key_bindings = [
  { key = "q", command = "quit" },
  { key = "ctrl+g", command = "vault_selector_modal_toggle" },
  { key = "?", command = "help_modal_toggle" },
+ { key = "ctrl+alt+e", command = "exec:vi %note_path" },
+ { key = "ctrl+alt+o", command = "spawn:open obsidian://open?vault=%vault&file=%note" },
 ]
 
 [splash]


### PR DESCRIPTION
### [Add arbitrary (sync, spawn) command execution](https://github.com/erikjuhani/basalt/pull/108/commits/750108f3282af5e947c23eb88ff3b5f8f196d0e4)

This commit adds two additional keywords (`exec:`, `spawn:`) for
executing arbitrary commands when defining key maps.

There are three special variables that are expanded into actual values.

- `%vault`: The name of the vault
- `%note`: The name of the selected note
- `%note_path`: The absolute path to the selected note

For example the command can be used to open obsidian using the obsidian
uri pattern:

```
  { key = "ctrl+alt+o", command = "spawn:open obsidian://open?vault=%vault&file=%note" },
```

Or external editor like `nvim`:

```
  { key = "ctrl+alt+e", command = "exec:nvim %note_path" },
```