### PR TITLE
Add full screen mode to explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "basalt-tui"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "basalt-core",
  "basalt-widgets",

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.10.3 (Sep, 15 2025)
+
+This release adds the support to easily hide and expand the explorer pane (file tree). Expanding and hiding is done with h, l and arrow left, and arrow right.
+
+When explorer is expanded a ⟹  symbol is shown for clarity of the current state.
+
+### Added
+
+- [Support expandable explorer commands in Explorer widget](https://github.com/erikjuhani/basalt/commit/4e815790a30f4ee949fbc25648e2c676dd19ab59)
+- [Add hide_pane and expand_pane explorer commands](https://github.com/erikjuhani/basalt/commit/18f2f0b06c6b73eaa120852a845e4d33796980b1)
+
+### Fixed
+
+- [Fix crash when note editor has no width available](https://github.com/erikjuhani/basalt/commit/f52d084cdbec9c7e49d82a7f0c89a0b6d5d950a7)
+
 ## 0.10.2 (Sep, 13 2025)
 
 Deprecated the following config commands:
@@ -13,6 +28,8 @@ Use these instead:
 - "note_editor_experimental_set_edit_view"
 - "note_editor_experimental_set_read_view" and
 - "note_editor_experimental_exit"
+
+### Changed
 
 - [Change note editor views and modes to follow Obsidian equivalent](https://github.com/erikjuhani/basalt/commit/371df9adf40624762dbf81b36c7395c7a5c34d3b)
 

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -6,7 +6,7 @@ Basalt TUI application for Obsidian notes.
 readme = "../README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "MIT"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 
 [dependencies]

--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -23,6 +23,8 @@
 # explorer_sort: toggles note and folder sorting between A-z and Z-a 
 # explorer_toggle: toggles explorer pane
 # explorer_toggle_outline: toggles outline pane
+# explorer_hide_pane: hides pane by steps, from full-width to regular width, to hidden
+# explorer_expand_pane: explands pane by steps, from hiddent to regular width, to full-width
 # explorer_switch_pane_next: switches focus to next pane
 # explorer_switch_pane_previous: switches focus to previous pane
 # explorer_scroll_up_one: scrolls the selector up by one
@@ -108,6 +110,10 @@ key_bindings = [
  { key = "up", command = "explorer_up" },
  { key = "down", command = "explorer_down" },
  { key = "t", command = "explorer_toggle" },
+ { key = "h", command = "explorer_hide_pane" },
+ { key = "l", command = "explorer_expand_pane" },
+ { key = "left", command = "explorer_hide_pane" },
+ { key = "right", command = "explorer_expand_pane" },
  { key = "s", command = "explorer_sort" },
  { key = "tab", command = "explorer_switch_pane_next" },
  { key = "shift+backtab", command = "explorer_switch_pane_previous" },

--- a/basalt/src/command.rs
+++ b/basalt/src/command.rs
@@ -39,6 +39,8 @@ pub(crate) enum Command {
     ExplorerToggleOutline,
     ExplorerSwitchPaneNext,
     ExplorerSwitchPanePrevious,
+    ExplorerHidePane,
+    ExplorerExpandPane,
     ExplorerScrollUpOne,
     ExplorerScrollDownOne,
     ExplorerScrollUpHalfPage,
@@ -106,6 +108,8 @@ fn str_to_command(s: &str) -> Option<Command> {
         "explorer_toggle" => Some(Command::ExplorerToggle),
         "explorer_toggle_outline" => Some(Command::ExplorerToggleOutline),
         "explorer_switch_pane_next" => Some(Command::ExplorerSwitchPaneNext),
+        "explorer_hide_pane" => Some(Command::ExplorerHidePane),
+        "explorer_expand_pane" => Some(Command::ExplorerExpandPane),
         "explorer_switch_pane_previous" => Some(Command::ExplorerSwitchPanePrevious),
         "explorer_scroll_up_one" => Some(Command::ExplorerScrollUpOne),
         "explorer_scroll_down_one" => Some(Command::ExplorerScrollDownOne),
@@ -216,6 +220,8 @@ impl From<Command> for Message<'_> {
             Command::ExplorerSort => Message::Explorer(explorer::Message::Sort),
             Command::ExplorerToggle => Message::Explorer(explorer::Message::Toggle),
             Command::ExplorerToggleOutline => Message::Explorer(explorer::Message::ToggleOutline),
+            Command::ExplorerHidePane => Message::Explorer(explorer::Message::HidePane),
+            Command::ExplorerExpandPane => Message::Explorer(explorer::Message::ExpandPane),
             Command::ExplorerSwitchPaneNext => Message::Explorer(explorer::Message::SwitchPaneNext),
             Command::ExplorerSwitchPanePrevious => {
                 Message::Explorer(explorer::Message::SwitchPanePrevious)

--- a/basalt/src/help.txt
+++ b/basalt/src/help.txt
@@ -61,6 +61,9 @@ INTERFACE
     and down through the list, and press Enter to select and view a note. The
     explorer panel can be toggled on/off to give more space to the note editor.
 
+    Explorer panel can be expanded and hidden. The Explorer panel has a ⟹
+    symbol indicator when it is expanded.
+
     DEFAULT KEY BINDINGS
 
       ‹q›,        Quit the application
@@ -71,6 +74,8 @@ INTERFACE
       ‹↑ / ↓›     Move selection up / down
       ‹s›         Toggle note sorting
       ‹t›         Toggle explorer panel visibility
+      ‹← / h›     Hide explorer panel
+      ‹→ / l›     Expand explorer panel
       ‹↩ Enter›   Select and view the highlighted note
 
       ‹Tab›       Switch to next pane

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -488,7 +488,7 @@ impl<'text_buffer> StatefulWidget for Editor<'text_buffer> {
             textarea.render(rect, buf);
         }
 
-        if r_len as u16 > inner_area.height {
+        if r_len as u16 > inner_area.height && inner_area.width > 0 {
             StatefulWidget::render(
                 widgets::Scrollbar::new(ScrollbarOrientation::VerticalRight),
                 area,

--- a/basalt/src/outline.rs
+++ b/basalt/src/outline.rs
@@ -48,13 +48,7 @@ pub fn update<'a>(message: &Message, state: &mut OutlineState) -> Option<AppMess
             state.set_active(false);
             return Some(AppMessage::SetActivePane(ActivePane::NoteEditor));
         }
-        Message::Toggle => {
-            state.toggle();
-            if !state.is_open() {
-                state.set_active(false);
-                return Some(AppMessage::SetActivePane(ActivePane::NoteEditor));
-            }
-        }
+        Message::Toggle => state.toggle(),
         Message::Select => {
             if let Some(item) = state.selected() {
                 return Some(AppMessage::NoteEditor(note_editor::Message::SetRow(

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -197,6 +197,8 @@ key_bindings = [
 # explorer_sort: toggles note and folder sorting between A-z and Z-a 
 # explorer_toggle: toggles explorer pane
 # explorer_toggle_outline: toggles outline pane
+# explorer_hide_pane: hides pane by steps, from full-width to regular width, to hidden
+# explorer_expand_pane: explands pane by steps, from hiddent to regular width, to full-width
 # explorer_switch_pane_next: switches focus to next pane
 # explorer_switch_pane_previous: switches focus to previous pane
 # explorer_scroll_up_one: scrolls the selector up by one
@@ -282,6 +284,10 @@ key_bindings = [
  { key = "up", command = "explorer_up" },
  { key = "down", command = "explorer_down" },
  { key = "t", command = "explorer_toggle" },
+ { key = "h", command = "explorer_hide_pane" },
+ { key = "l", command = "explorer_expand_pane" },
+ { key = "left", command = "explorer_hide_pane" },
+ { key = "right", command = "explorer_expand_pane" },
  { key = "s", command = "explorer_sort" },
  { key = "tab", command = "explorer_switch_pane_next" },
  { key = "shift+backtab", command = "explorer_switch_pane_previous" },

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -6,4 +6,4 @@ cargo check --profile ci --workspace --all-targets
 cargo clippy --profile ci --workspace --all-targets -- -D warnings
 cargo test --profile ci --workspace --all-targets
 cargo build --profile ci --workspace --all-targets
-cargo package --no-verify
+cargo package --no-verify --allow-dirty


### PR DESCRIPTION
![basalt_expanding_explorer](https://github.com/user-attachments/assets/97055f8a-3516-4312-b24f-b43acea819af)

### [Change pre-push package to allow dirty (modified, but not committed)](https://github.com/erikjuhani/basalt/pull/129/commits/3f3cb15d4d29ec40369f57d5bbfbe3d4f1c35078)

The last step `cargo package` would fail the pre-push hook if any files
were modified, but not yet committed. This is too strict, as there are
use cases when you have modified files and want to push partially your
_committed_ changes.

Stashing before pre-push feels clunky and unergonomic thus, changing the
command to allow dirty files to exist (modified, but not committed).

### [Fix crash when note editor has no width available](https://github.com/erikjuhani/basalt/pull/129/commits/f52d084cdbec9c7e49d82a7f0c89a0b6d5d950a7)

The scrollbar widget would crash the application. This is mitigated by
checking the width of the note editor and if it's 0 or less we do not
render the scrollbar at all (nothing is visible anyways).

### [Add hide_pane and expand_pane explorer commands](https://github.com/erikjuhani/basalt/pull/129/commits/18f2f0b06c6b73eaa120852a845e4d33796980b1)

These commands enable users to expand or hide the explorer between
different visibility states (hidden, visible and full-width). Full-width
takes a larger portion of the available screen-estate to allow to see
larger file trees and longer filenames.

These commands are now mapped by default to:

- Hide: h or left arrow
- Expand: l or right arrow

Toggle is still the same ctrl+b.

### [Support expandable explorer commands in Explorer widget](https://github.com/erikjuhani/basalt/pull/129/commits/4e815790a30f4ee949fbc25648e2c676dd19ab59)

The expandable commands are `hide_panel` and `expand_panel`. Fixes https://github.com/erikjuhani/basalt/issues/107.

Explorer now supports three visibility modes: hidden, visible and
full-width. Full-width takes the complete panel width from the
note-editor and fills the available space with the explorer widget.

If explorer is expanded, a ⟹  symbol is shown for clarity of the state.

Change the toggle command to not change the activity state of the panel
as this can now be controlled with tab or shift-tab. Otherwise, it's a
bit confusing to the user when the active panel was not changed by the
user.