### PR TITLE
Add Renovate bot for automatic crate updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,23 @@
+name: Renovate
+
+on:
+  push:
+    branches: 
+      - main
+  schedule:
+    # Run every Monday and Thursday
+    - cron: '0 0 * * 1,4'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run renovate
+        uses: renovatebot/github-action@v43.0.12
+        with:
+          configurationFile: renovate-action.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate-action.json
+++ b/renovate-action.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "rebaseWhen": "behind-base-branch",
+  "schedule": ["on Monday and Thursday"],
+  "regexManagers": [
+    {
+      "fileMatch": ["(^|/)rust-toolchain\\.toml?$"],
+      "matchStrings": [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
+      ],
+      "depNameTemplate": "rust",
+      "lookupNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-tags"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["regex"],
+      "matchDepNames": ["rust"],
+      "commitMessageTopic": "Rust"
+    },
+    {
+      "matchDatasources": ["crate"],
+      "minimumReleaseAge": "3 days"
+    }
+  ]
+}


### PR DESCRIPTION
Uses the GitHub action version of renovate. The renovate-action.json contains the renovate configuration, and is partly derived from here: https://github.com/Turbo87/renovate-config/blob/master/rust/updateToolchain.json

Renovate workflow is configured to run every Tuesday and Thursday.

The renovate itself will also target Tuesday and Thursday, since, this is when new PRs are expected to be created. The workflow will also run with workflow_dispatch or when commits are pushed to main branch, in those cases, renovate should only update the existing PRs.