### PR TITLE
Move repository related configs to renovate GitHub workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,9 +5,18 @@ on:
     branches: 
       - main
   schedule:
-    # Run every Monday and Thursday
-    - cron: '0 0 * * 1,4'
+    - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      log_level:
+        description: 'Log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
+          - warn
 
 jobs:
   renovate:
@@ -21,7 +30,9 @@ jobs:
         env:
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: "optional"
-          LOG_LEVEL: "debug"
+          RENOVATE_GIT_AUTHOR: "renovate[bot] <renovate[bot]@users.noreply.github.com>"
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
         with:
           configurationFile: renovate-config.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,13 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":disableDependencyDashboard"],
-  "username": "renovate",
-  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "extends": ["config:recommended", ":disableDependencyDashboard", "schedule:daily"],
   "rebaseWhen": "behind-base-branch",
-  "schedule": ["on Monday and Thursday"],
-  "platform": "github",
-  "repositories": ["erikjuhani/basalt"],
-  "onboarding": false,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Also changed the cadence of renovate runs to daily instead of selected two days in a week. It felt a bit limiting after all.

Also removed redundant configuration fields.