### PR TITLE
Add assertion to make sure the lockfile does not need to be updated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
                                   musl-tools
 
       - name: Build binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --locked --release --target ${{ matrix.target }}
 
       - name: Prepare artifact
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check
-      run: cargo check --profile ci --workspace --all-targets
+      run: cargo check --locked --profile ci --workspace --all-targets
 
     - name: Clippy
       run: cargo clippy --profile ci --workspace --all-targets -- -D warnings

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -2,7 +2,7 @@
 
 set -e
 
-cargo check --profile ci --workspace --all-targets
+cargo check --locked --profile ci --workspace --all-targets
 cargo clippy --profile ci --workspace --all-targets -- -D warnings
 cargo test --profile ci --workspace --all-targets
 cargo build --profile ci --workspace --all-targets


### PR DESCRIPTION
The `--locked` option asserts that the exact same dependencies are versions are used as when the existing Cargo.lock file was generated.

Cargo will fail if:

- The lock file is missing.
- Cargo attempted to change the lock file due to a different dependency resolution.

I might push incomplete commits to main, which did recently happen with 46e7e4d. This change should prevent that from happening again.