### PR TITLE
Move some renovate config vars from workflow to config json

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Run renovate
         uses: renovatebot/github-action@v43.0.12
         env:
-          RENOVATE_ONBOARDING: "false"
-          RENOVATE_REQUIRE_CONFIG: "optional"
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
         with:

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":disableDependencyDashboard", "schedule:daily"],
   "rebaseWhen": "behind-base-branch",
+  "onboarding": false,
+  "requireConfig": "optional",
+  "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
This makes the static configuration be defined in a single place, and then the dynamic variants are controlled with the env vars of the workflow.

Changed the PR body template to simpler variant, which for example removed the controls, like the rebase PR checkbox. The checkbox does not function immediately so it's quite irrelevant.