### PR TITLE
Pin renovate to version `41.124.1`

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -37,5 +37,6 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
         with:
+          renovate-version: 41.124.1
           configurationFile: renovate-config.json
           token: '${{ steps.app-token.outputs.token }}'


### PR DESCRIPTION
Pinned the version to allow renovate to work again with cargo. The following error started happening after `41.125.0` version:

```
error: failed to acquire package cache lock\n\nCaused by:\n  failed to
open: /home/ubuntu/.cargo/.package-cache\n\nCaused by:\n  failed to
create directory `/home/ubuntu/.cargo`\n\nCaused by:\n  File exists (os
error 17)\n
```

which in turn would fail to create any update PRs since the cargo command fails to that error.

There is an open issue regarding this: https://github.com/renovatebot/renovate/issues/38378