### PR TITLE
Add daily schedule back to renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    "schedule:daily"
   ],
   "rebaseWhen": "behind-base-branch",
   "onboarding": false,


### PR DESCRIPTION
This makes sure that when I'm merging renovate or other PRs the renovate PRs will only get rebased and new PRs are not opened.

Previously I thought that the schedule:daily was causing the issue of PRs not being opened by renovate, but turns out it was because of some renovate update that prevented cargo command from running.

Fixed this temporarily by pinning renovate in this commit: 3e57f73