### PR TITLE
Enable commit body table for more expressive update commits

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -7,6 +7,7 @@
   ],
   "rebaseWhen": "behind-base-branch",
   "onboarding": false,
+  "commitBodyTable": true,
   "minimumReleaseAge": "3 days",
   "osvVulnerabilityAlerts": true,
   "requireConfig": "optional",


### PR DESCRIPTION
Currently the commit only contains the title, but sometimes it might be useful to have additional information in the commit body. I would argue that the table is the bare-minimum, a bit similar to dependabot equivalent.