### PR TITLE
Workflow improvements actionlint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,9 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
-    name: Release
+  # TODO: Separate into build and release jobs as both have very distinct focus
+  build_and_release:
+    name: Build and Release
 
     permissions:
       contents: write # Needed to create releases and update files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         run: rustup toolchain install
 
       - name: Add Rust target
-        run: rustup target add ${MATRIX_TARGET}
+        run: rustup target add "${MATRIX_TARGET}"
 
       - name: Cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -81,7 +81,7 @@ jobs:
                                   musl-tools
 
       - name: Build binary
-        run: cargo build --locked --release --target ${MATRIX_TARGET}
+        run: cargo build --locked --release --target "${MATRIX_TARGET}"
 
       - name: Prepare artifact
         shell: bash
@@ -109,7 +109,7 @@ jobs:
         run: |
           archive="${ARCHIVE}"
           certutil -hashfile "${archive}" SHA256 > "${archive}.sha256"
-          echo "ARTIFACT_SUM=${archive}.sha256" >> $GITHUB_ENV
+          echo "ARTIFACT_SUM=${archive}.sha256" >> "$GITHUB_ENV"
 
       - name: Generate checksum (Unix)
         shell: bash
@@ -117,7 +117,7 @@ jobs:
         run: |
           archive="${ARCHIVE}"
           shasum -a 256 "${archive}" > "${archive}.sha256"
-          echo "ARTIFACT_SUM=${archive}.sha256" >> $GITHUB_ENV
+          echo "ARTIFACT_SUM=${archive}.sha256" >> "$GITHUB_ENV"
 
       - name: Upload artifact and checksum to existing GitHub release
         env:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,6 +31,19 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+          sparse-checkout: |
+            .cargo
+            .github
+            basalt/Cargo.toml
+            basalt-core/Cargo.toml
+            basalt-widgets/Cargo.toml
+            Cargo.lock
+            Cargo.toml
+            README.md
+            renovate-config.json
+            rust-toolchain.toml
+          sparse-checkout-cone-mode: false
+
 
       - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: app-token

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -25,6 +25,11 @@ jobs:
           sparse-checkout: |
             .github/workflows
 
+      - name: actionlint
+        uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc # v2.0.1
+        with:
+          flags: "-ignore SC2153" # Possible misspelling false flags
+
       - name: Pinact
         uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2
         with:

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+          sparse-checkout: |
+            .github/workflows
 
       - name: Pinact
         uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2


### PR DESCRIPTION
### [Rename build job to build_and_release in Release workflow](https://github.com/erikjuhani/basalt/commit/9a23e03b389a4ffcb68f62aa1c572319b025a48a)

This makes it a bit more clear on what it does, however, as both of
these are distinct jobs, they should be clearly, separate. Added a todo
comment for that.

[Add sparse-checkout to Renovate and Security workflows](https://github.com/erikjuhani/basalt/pull/174/commits/134d007cc3e15ca211ef4450be3d6286d9bb7df3)

The aim here is to improve the speed the workflows, and explicitly
select what should be checkout in each workflow, especially the security
one that requires just the .github folder.

### [Add actionlint step to workflow security](https://github.com/erikjuhani/basalt/pull/174/commits/269c4d819f5cea1d997070ed96465c2ef352bf0e)

Fix the few globbing lint issues. I decided to ignore SC2153 as it
produced only false flags on my run. It is the code for possible
misspelling and in this case the variable was set to the env. If I were
to use ${{ env.VAR }} zizmor would complain!