### PR TITLE
Renovate changes

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -25,6 +25,17 @@
       "depNameTemplate": "rust",
       "packageNameTemplate": "rust-lang/rust",
       "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        ".github/workflows/renovate.yml"
+      ],
+      "matchStrings": [
+        "renovate-version: (?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "ghcr.io/renovatebot/renovate",
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
### [Use the recommended renovate preset 'best-practices'](https://github.com/erikjuhani/basalt/pull/180/commits/689218a5b44025d7934583e0e39f083fdc3fbd3f)

Renovate recommends to use 'best-practices' preset instead of
'config-recommended'.

More info here: https://docs.renovatebot.com/upgrade-best-practices/#use-the-configbest-practices-preset

### [Disable semantic commits in renovate config](https://github.com/erikjuhani/basalt/pull/180/commits/6832617efca80ae984c7b51538fd85a997f9cc48)

This project is not using conventional/semantic commits, but instead
rely on _manual_ git trailers.

### [Add customManager for renovate version in the renovate workflow](https://github.com/erikjuhani/basalt/pull/180/commits/bbf763a686e43ec70ccf9eb0df51a4a22d180bb3)

This should make sure that the renovate-version is explicit, and also
kept up-to-date.