### PR TITLE
Add Renovate configuration for zizmor version updates

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -37,6 +37,17 @@
       ],
       "depNameTemplate": "ghcr.io/renovatebot/renovate",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        ".github/workflows/workflow-security.yml"
+      ],
+      "matchStrings": [
+        "name: zizmor\\s+uses: zizmorcore/zizmor-action@[a-f0-9]+ # [^\\s]+\\s+with:[\\s\\S]*?version: (?<currentValue>v[0-9.]+)"
+      ],
+      "depNameTemplate": "zizmorcore/zizmor",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Add a new custom regex manager to track and update the zizmor version in workflow-security.yml. This enables automatic version updates for the zizmor dependency similar to the renovate-version manager.