### PR TITLE
Remove renovate-pr-approver from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 * @erikjuhani
-* @renovate-pr-approver[bot]


### PR DESCRIPTION
Cannot add bots as CODEOWNERS. I removed the CODEOWNER review requirement for now.

Reference: https://github.com/orgs/community/discussions/23064