### PR TITLE
Edit timestamp to be optionnal in json with fallback to 0

### DIFF
--- a/basalt-core/src/obsidian/vault.rs
+++ b/basalt-core/src/obsidian/vault.rs
@@ -213,7 +213,7 @@ impl<'de> Deserialize<'de> for Vault {
         struct Json {
             path: PathBuf,
             open: Option<bool>,
-            ts: u64,
+            ts: Option<u64>,
         }
 
         impl TryFrom<Json> for Vault {
@@ -228,7 +228,7 @@ impl<'de> Deserialize<'de> for Vault {
                     name,
                     path,
                     open: open.unwrap_or(false),
-                    ts,
+                    ts: ts.unwrap_or(0),
                 })
             }
         }


### PR DESCRIPTION
<img width="2016" height="857" alt="image" src="https://github.com/user-attachments/assets/f61a1b82-4593-4412-b992-12d492b3dc27" />

Because of a missing `ts` timestamp field, that is not always generated. It is impossible to open `basalt`

My config is based on a Immutable system, I can't change the config easily and basalt doesn't seem to use this value anyways.


Instead of a hard crash, I suggest the following 2 lines changes. Similar to how `open` already works.