### PR TITLE
Fixes 'sticky' symbols when switching between read and edit

### DIFF
--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -6,8 +6,8 @@ use ratatui::{
     style::{Color, Stylize},
     text::Line,
     widgets::{
-        Block, BorderType, Clear, Padding, Paragraph, Scrollbar, ScrollbarOrientation,
-        ScrollbarState, StatefulWidget, Widget,
+        Block, BorderType, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+        StatefulWidget, Widget,
     },
 };
 
@@ -62,11 +62,6 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
         state.resize_viewport(inner_area.as_size());
 
         state.update_layout();
-
-        // Clear visual artifacts between read and edit mode
-        if matches!(state.view, View::Edit(..)) {
-            Clear.render(area, buf);
-        }
 
         let mut lines = state.virtual_document.meta().to_vec();
         lines.extend(state.virtual_document.lines().to_vec());

--- a/basalt/src/note_editor/render.rs
+++ b/basalt/src/note_editor/render.rs
@@ -101,7 +101,11 @@ fn render_raw_line<'a>(
     max_width: usize,
 ) -> Vec<VirtualLine<'a>> {
     text_wrap_internal(
-        line,
+        // TODO: Replace with `»` as a synthetic symbol for tabs
+        // Tab characters need to be replaced to spaces or other characters as the tab characters
+        // will break the UI. Similarly the same issue that I was facing was solved by replacing
+        // the tab characters: https://github.com/ratatui/ratatui/issues/1606#issuecomment-3172769529
+        &line.replace("\t", "  "),
         Style::default(),
         prefix,
         source_range,


### PR DESCRIPTION
The sticky key effect was visible for example with task lists when tasks were intended with tabs in the source. These tab characters would never replace the existing symbols from the buffer. The sticky symbols issue was fixed by replacing the tab characters with two spaces.

Reference: https://github.com/ratatui/ratatui/issues/1606#issuecomment-3172769529