### PR TITLE
Remove widget ref in app and statusbar

### DIFF
--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -3,7 +3,7 @@ use ratatui::{
     buffer::Buffer,
     crossterm::event::{self, Event, KeyEvent, KeyEventKind},
     layout::{Constraint, Layout, Rect, Size},
-    widgets::{StatefulWidget, StatefulWidgetRef},
+    widgets::StatefulWidget,
     DefaultTerminal,
 };
 
@@ -218,7 +218,7 @@ impl<'a> App<'a> {
         terminal.draw(move |frame| {
             let area = frame.area();
             let buf = frame.buffer_mut();
-            self.render_ref(area, buf, state);
+            self.render(area, buf, state);
         })?;
 
         Ok(())
@@ -481,7 +481,7 @@ impl<'a> App<'a> {
         );
 
         let status_bar = StatusBar::default();
-        status_bar.render_ref(statusbar, buf, &mut status_bar_state);
+        status_bar.render(statusbar, buf, &mut status_bar_state);
 
         self.render_modals(area, buf, state)
     }
@@ -501,10 +501,10 @@ impl<'a> App<'a> {
     }
 }
 
-impl<'a> StatefulWidgetRef for App<'a> {
+impl<'a> StatefulWidget for &App<'a> {
     type State = AppState<'a>;
 
-    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         self.render_main(area, buf, state);
     }
 }

--- a/basalt/src/statusbar.rs
+++ b/basalt/src/statusbar.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Constraint, Flex, Layout, Rect},
     style::{Color, Stylize},
     text::{Line, Span, Text},
-    widgets::{StatefulWidgetRef, Widget},
+    widgets::{StatefulWidget, Widget},
 };
 
 #[derive(Default, Clone, PartialEq)]
@@ -30,10 +30,10 @@ pub struct StatusBar<'a> {
     _lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> StatefulWidgetRef for StatusBar<'a> {
+impl<'a> StatefulWidget for StatusBar<'a> {
     type State = StatusBarState<'a>;
 
-    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let [left, right] = Layout::horizontal([Constraint::Fill(1), Constraint::Length(28)])
             .flex(Flex::SpaceBetween)
             .areas(area);


### PR DESCRIPTION
For some reason I missed these two instances. Fix the compiler errors. Original commit: 03f5af3eb000975ede73d6896f4dfef99f65a7b1