### PR TITLE
Add native explorer find filter

### DIFF
--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -22,6 +22,7 @@
 # explorer_open: opens the selected note in note viewer
 # explorer_sort: toggles note and folder sorting between A-z and Z-a
 # explorer_toggle: toggles explorer pane
+# explorer_toggle_input_find: opens input modal to filter note list
 # explorer_toggle_outline: toggles outline pane
 # explorer_toggle_input_rename: opens input modal to rename selected note or directory
 # explorer_hide_pane: hides pane by steps, from full-width to regular width, to hidden
@@ -126,6 +127,7 @@ key_bindings = [
  { key = "left", command = "explorer_hide_pane" },
  { key = "right", command = "explorer_expand_pane" },
  { key = "s", command = "explorer_sort" },
+ { key = "f", command = "explorer_toggle_input_find" },
  { key = "r", command = "explorer_toggle_input_rename" },
  { key = "tab", command = "explorer_switch_pane_next" },
  { key = "shift+backtab", command = "explorer_switch_pane_previous" },

--- a/basalt/src/command.rs
+++ b/basalt/src/command.rs
@@ -36,6 +36,7 @@ pub(crate) enum Command {
     ExplorerOpen,
     ExplorerSort,
     ExplorerToggle,
+    ExplorerToggleInputFind,
     ExplorerToggleInputRename,
     ExplorerToggleOutline,
     ExplorerSwitchPaneNext,
@@ -115,6 +116,7 @@ fn str_to_command(s: &str) -> Option<Command> {
         "explorer_open" => Some(Command::ExplorerOpen),
         "explorer_sort" => Some(Command::ExplorerSort),
         "explorer_toggle" => Some(Command::ExplorerToggle),
+        "explorer_toggle_input_find" => Some(Command::ExplorerToggleInputFind),
         "explorer_toggle_outline" => Some(Command::ExplorerToggleOutline),
         "explorer_toggle_input_rename" => Some(Command::ExplorerToggleInputRename),
         "explorer_switch_pane_next" => Some(Command::ExplorerSwitchPaneNext),
@@ -237,6 +239,9 @@ impl From<Command> for Message<'_> {
             Command::ExplorerOpen => Message::Explorer(explorer::Message::Open),
             Command::ExplorerSort => Message::Explorer(explorer::Message::Sort),
             Command::ExplorerToggle => Message::Explorer(explorer::Message::Toggle),
+            Command::ExplorerToggleInputFind => {
+                Message::Explorer(explorer::Message::ToggleInputFind)
+            }
             Command::ExplorerToggleOutline => Message::Explorer(explorer::Message::ToggleOutline),
             Command::ExplorerToggleInputRename => {
                 Message::Explorer(explorer::Message::ToggleInputRename)


### PR DESCRIPTION
## Summary
- add a native explorer find action (`explorer_toggle_input_find`) wired through command parsing and message routing
- reuse the existing input modal with a new callback mode to submit find queries directly into explorer state
- add filtered explorer view state with fuzzy-ish matching, query display in the title, and tests for filter/clear behavior

## Verification
- `cargo +stable fmt --all`
- `cargo +stable test`
- `cargo +stable build`

## Notes
- this keeps search entirely in-app (no external editor/process) and preserves existing explorer navigation/open behavior over matched notes