### PR TITLE
Fix release workflow deadlock caused by conflicting concurrency groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: build-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
When `build.yml` is called via `workflow_call`, `github.workflow`
resolves to the caller's name ("Release"), causing both `release.yml`
and `build.yml` to compete for the same concurrency group. GitHub
detects this as a deadlock and cancels the run.

Replace the old concurrency block (which used `github.workflow` as the
group prefix) with a hardcoded `build-` prefix so the group name is
always distinct from the caller's group, preventing the deadlock while
still satisfying concurrency limits.