### PR TITLE
docs: support installation via aquaproj/aqua

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Basalt is a cross-platform TUI (Terminal User Interface) for managing Obsidian v
   ```sh
   cargo install basalt-tui
   ```
+
 - Using [aqua](https://aquaproj.github.io/docs/install):
   ```sh
   aqua g -i erikjuhani/basalt
   ```
+
 Or download a pre-compiled binary from the [latest release](https://github.com/erikjuhani/basalt/releases/latest), extract it, and move the `basalt` binary to a location in your `PATH`.
 
 ## Configuration

--- a/docs/Getting started/Installation.md
+++ b/docs/Getting started/Installation.md
@@ -1,11 +1,17 @@
 ## Installation
 
-[[Basalt]] is available to install via [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) and as pre-compiled binaries from [GitHub releases](https://github.com/erikjuhani/basalt/releases).
+[[Basalt]] is available to install via [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html), [aqua](https://aquaproj.github.io/docs/install), and as pre-compiled binaries from [GitHub releases](https://github.com/erikjuhani/basalt/releases).
 
 ### Cargo
 
 ```
 cargo install basalt-tui
+```
+
+### aqua
+
+```
+aqua g -i erikjuhani/basalt
 ```
 
 ### Pre-compiled binaries


### PR DESCRIPTION
Add installation instructions using [aqua](https://aquaproj.github.io/) to the README.

I added to the **aqua-registry** (see [aquaproj/aqua-registry#49226](https://github.com/aquaproj/aqua-registry/issues/49226)), users can now easily install it using the following command:

```sh
aqua g -i erikjuhani/basalt
```