### PR TITLE
feat(parser,render): add inline styles and standalone block elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +85,7 @@ dependencies = [
  "ratatui",
  "serde",
  "similar-asserts",
+ "syntect",
  "textwrap",
  "thiserror 2.0.18",
  "toml",
@@ -100,12 +107,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -113,6 +138,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -232,6 +263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -445,8 +485,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -477,6 +528,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -720,6 +781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +858,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1008,6 +1085,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1146,15 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -1256,6 +1355,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1575,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex 0.16.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,7 +1638,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags 2.11.0",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset",
@@ -1594,12 +1729,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1607,6 +1744,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "toml"
@@ -1737,6 +1884,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1931,6 +2088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2282,15 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/basalt-core/src/markdown.rs
+++ b/basalt-core/src/markdown.rs
@@ -65,6 +65,8 @@ pub enum Style {
     Strikethrough,
     /// Bold/strong style (e.g. `**strong**`).
     Strong,
+    /// Inline math style (e.g. `$formula$`).
+    InlineMath,
 }
 
 /// Represents the variant of a list or task item (checked, unchecked, etc.).
@@ -299,6 +301,8 @@ impl Node {
                     last_node.push_text_node(node);
                 }
             }
+            // Rule and DisplayMath store no inline text — no-op.
+            MarkdownNode::Rule | MarkdownNode::DisplayMath { .. } => {}
         }
     }
 }
@@ -338,6 +342,12 @@ pub enum MarkdownNode {
     Item {
         kind: Option<ItemKind>,
         text: Text,
+    },
+    /// A horizontal rule (thematic break) rendered as a separator line.
+    Rule,
+    /// A display math block (e.g. `$$...$$`), storing the formula content.
+    DisplayMath {
+        content: String,
     },
 }
 
@@ -574,13 +584,37 @@ impl<'a> Parser<'a> {
                     ));
                 }
             }
-            Event::InlineMath(_)
-            | Event::DisplayMath(_)
-            | Event::Html(_)
+            Event::Rule => {
+                // Finalize any in-progress node before pushing Rule.
+                if let Some(node) = self.current_node.take() {
+                    self.output.push(node);
+                }
+                self.output.push(Node::new(MarkdownNode::Rule, range));
+            }
+            Event::InlineMath(text) => {
+                self.push_text_node(TextNode::new(text.to_string(), Some(Style::InlineMath)))
+            }
+            Event::DisplayMath(content) => {
+                // Finalize any in-progress node before pushing DisplayMath.
+                // pulldown-cmark wraps $$...$$ in a Paragraph container; the Paragraph
+                // end tag will be ignored because current_node is cleared here.
+                if let Some(node) = self.current_node.take() {
+                    // Only push the preceding node if it has content (not the empty wrapper).
+                    if !matches!(&node.markdown_node, MarkdownNode::Paragraph { text } if text.0.is_empty()) {
+                        self.output.push(node);
+                    }
+                }
+                self.output.push(Node::new(
+                    MarkdownNode::DisplayMath {
+                        content: content.to_string(),
+                    },
+                    range,
+                ));
+            }
+            Event::Html(_)
             | Event::InlineHtml(_)
             | Event::SoftBreak
             | Event::HardBreak
-            | Event::Rule
             | Event::FootnoteReference(_) => {
                 // TODO: Not yet implemented
             }
@@ -774,5 +808,53 @@ mod tests {
         tests
             .iter()
             .for_each(|test| assert_eq!(from_str(test.0), test.1));
+    }
+
+    #[test]
+    fn test_rule_and_math() {
+        // Horizontal rule produces a single Rule node.
+        let rule_nodes = from_str("---");
+        assert_eq!(rule_nodes.len(), 1);
+        assert_eq!(rule_nodes[0].markdown_node, MarkdownNode::Rule);
+
+        // Inline math produces a Paragraph with an InlineMath-styled TextNode.
+        let inline_math_nodes = from_str("$E = mc^2$");
+        assert_eq!(inline_math_nodes.len(), 1);
+        if let MarkdownNode::Paragraph { text } = &inline_math_nodes[0].markdown_node {
+            let nodes: Vec<_> = text.clone().into_iter().collect();
+            assert_eq!(nodes.len(), 1);
+            assert_eq!(nodes[0].content, "E = mc^2");
+            assert_eq!(nodes[0].style, Some(Style::InlineMath));
+        } else {
+            panic!("Expected Paragraph node for inline math");
+        }
+
+        // Inline math mixed with plain text produces three TextNodes.
+        let mixed_nodes = from_str("Hello $x$ world");
+        assert_eq!(mixed_nodes.len(), 1);
+        if let MarkdownNode::Paragraph { text } = &mixed_nodes[0].markdown_node {
+            let nodes: Vec<_> = text.clone().into_iter().collect();
+            assert_eq!(nodes.len(), 3);
+            assert_eq!(nodes[0].content, "Hello ");
+            assert_eq!(nodes[0].style, None);
+            assert_eq!(nodes[1].content, "x");
+            assert_eq!(nodes[1].style, Some(Style::InlineMath));
+            assert_eq!(nodes[2].content, " world");
+            assert_eq!(nodes[2].style, None);
+        } else {
+            panic!("Expected Paragraph node for mixed inline math");
+        }
+
+        // Display math produces a single DisplayMath node with the formula content.
+        let display_math_nodes = from_str("$$\n\\int_0^\\infty e^{-x} dx = 1\n$$");
+        assert_eq!(display_math_nodes.len(), 1);
+        if let MarkdownNode::DisplayMath { content } = &display_math_nodes[0].markdown_node {
+            assert!(content.contains("\\int_0^\\infty"));
+        } else {
+            panic!(
+                "Expected DisplayMath node, got {:?}",
+                display_math_nodes[0].markdown_node
+            );
+        }
     }
 }

--- a/basalt-core/src/markdown.rs
+++ b/basalt-core/src/markdown.rs
@@ -504,13 +504,20 @@ impl<'a> Parser<'a> {
                 },
                 range,
             )),
-            Tag::CodeBlock(_) => self.push_node(Node::new(
-                MarkdownNode::CodeBlock {
-                    lang: None,
-                    text: Text::default(),
-                },
-                range,
-            )),
+            Tag::CodeBlock(kind) => {
+                use pulldown_cmark::CodeBlockKind;
+                let lang = match kind {
+                    CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.to_string()),
+                    _ => None,
+                };
+                self.push_node(Node::new(
+                    MarkdownNode::CodeBlock {
+                        lang,
+                        text: Text::default(),
+                    },
+                    range,
+                ))
+            }
             Tag::Item => self.push_node(Node::new(
                 MarkdownNode::Item {
                     kind: None,
@@ -600,7 +607,8 @@ impl<'a> Parser<'a> {
                 // end tag will be ignored because current_node is cleared here.
                 if let Some(node) = self.current_node.take() {
                     // Only push the preceding node if it has content (not the empty wrapper).
-                    if !matches!(&node.markdown_node, MarkdownNode::Paragraph { text } if text.0.is_empty()) {
+                    if !matches!(&node.markdown_node, MarkdownNode::Paragraph { text } if text.0.is_empty())
+                    {
                         self.output.push(node);
                     }
                 }
@@ -731,7 +739,53 @@ mod tests {
         heading(HeadingLevel::H6, str, range)
     }
 
+    fn code_block(lang: Option<&str>, text: &str, range: Range<usize>) -> Node {
+        Node::new(
+            MarkdownNode::CodeBlock {
+                lang: lang.map(|s| s.to_string()),
+                text: text.into(),
+            },
+            range,
+        )
+    }
+
     use super::*;
+
+    #[test]
+    fn test_code_block_lang_extraction() {
+        // Fenced with language
+        let input = indoc! {"
+            ```rust
+            let x = 1;
+            ```
+        "};
+        let nodes = from_str(input);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0], code_block(Some("rust"), "let x = 1;\n", 0..22));
+
+        // Fenced without language
+        let input2 = indoc! {"
+            ```
+            plain code
+            ```
+        "};
+        let nodes2 = from_str(input2);
+        assert_eq!(nodes2.len(), 1);
+        assert_eq!(nodes2[0], code_block(None, "plain code\n", 0..18));
+
+        // Fenced with python
+        let input3 = indoc! {"
+            ```python
+            print('hi')
+            ```
+        "};
+        let nodes3 = from_str(input3);
+        assert_eq!(nodes3.len(), 1);
+        assert_eq!(
+            nodes3[0],
+            code_block(Some("python"), "print('hi')\n", 0..25)
+        );
+    }
 
     #[test]
     fn test_parse() {

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -22,6 +22,7 @@ etcetera = "0.11.0"
 thiserror = "2.0.16"
 unicode-width = "0.2.0"
 natord = "1.0.9"
+syntect = { version = "5.3.0", default-features = false, features = ["default-fancy"] }
 
 [dev-dependencies]
 indoc = "2"

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -6,6 +6,8 @@ use ratatui::{
     widgets::{StatefulWidget, Widget},
     DefaultTerminal,
 };
+use syntect::highlighting::ThemeSet;
+use syntect::parsing::SyntaxSet;
 
 use std::{
     cell::RefCell,
@@ -40,6 +42,47 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const HELP_TEXT: &str = include_str!("./help.txt");
 
+#[derive(Clone)]
+pub struct SyntectContext {
+    pub syntax_set: SyntaxSet,
+    pub theme: syntect::highlighting::Theme,
+    pub selection_color: Option<ratatui::style::Color>,
+}
+
+impl std::fmt::Debug for SyntectContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyntectContext").finish_non_exhaustive()
+    }
+}
+
+impl SyntectContext {
+    pub fn new() -> Self {
+        let syntax_set = SyntaxSet::load_defaults_newlines();
+        let theme_set = ThemeSet::load_defaults();
+        let theme = theme_set
+            .themes
+            .get("base16-ocean.dark")
+            .or_else(|| theme_set.themes.values().next())
+            .cloned()
+            .unwrap_or_default();
+        let selection_color = theme
+            .settings
+            .selection
+            .map(|c| ratatui::style::Color::Rgb(c.r, c.g, c.b));
+        Self {
+            syntax_set,
+            theme,
+            selection_color,
+        }
+    }
+}
+
+impl Default for SyntectContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Default, Clone, PartialEq)]
 pub enum ScrollAmount {
     #[default]
@@ -72,6 +115,7 @@ pub struct AppState<'a> {
     splash_modal: SplashModalState<'a>,
     help_modal: HelpModalState,
     vault_selector_modal: VaultSelectorModalState<'a>,
+    syntect_ctx: Option<SyntectContext>,
 }
 
 impl<'a> AppState<'a> {
@@ -100,6 +144,10 @@ impl<'a> AppState<'a> {
             is_running,
             ..self.clone()
         }
+    }
+
+    pub fn syntect_ctx(&self) -> Option<&SyntectContext> {
+        self.syntect_ctx.as_ref()
     }
 }
 
@@ -237,6 +285,7 @@ impl<'a> App<'a> {
                 .into_iter()
                 .map(|message| toast::Toast::warn(&message, Duration::from_secs(5)))
                 .collect(),
+            syntect_ctx: Some(SyntectContext::new()),
             ..Default::default()
         };
 
@@ -498,6 +547,7 @@ impl<'a> App<'a> {
                     &selected_note.name,
                     &selected_note.path,
                     &config.symbols,
+                    state.syntect_ctx.as_ref(),
                 );
 
                 let vim_mode = config.vim_mode;

--- a/basalt/src/note_editor/ast.rs
+++ b/basalt/src/note_editor/ast.rs
@@ -103,6 +103,15 @@ pub enum Node {
         nodes: Vec<Node>,
         source_range: SourceRange<usize>,
     },
+    /// A horizontal rule (thematic break) rendered as a separator line.
+    Rule {
+        source_range: SourceRange<usize>,
+    },
+    /// A display math block (e.g. `$$...$$`), storing the formula content.
+    DisplayMath {
+        content: String,
+        source_range: SourceRange<usize>,
+    },
 }
 
 impl Node {
@@ -114,7 +123,9 @@ impl Node {
             | Self::List { source_range, .. }
             | Self::BlockQuote { source_range, .. }
             | Self::Item { source_range, .. }
-            | Self::Task { source_range, .. } => source_range,
+            | Self::Task { source_range, .. }
+            | Self::Rule { source_range, .. }
+            | Self::DisplayMath { source_range, .. } => source_range,
         }
     }
 
@@ -126,7 +137,9 @@ impl Node {
             | Self::List { source_range, .. }
             | Self::BlockQuote { source_range, .. }
             | Self::Item { source_range, .. }
-            | Self::Task { source_range, .. } => *source_range = new_range,
+            | Self::Task { source_range, .. }
+            | Self::Rule { source_range, .. }
+            | Self::DisplayMath { source_range, .. } => *source_range = new_range,
         }
     }
 
@@ -241,6 +254,23 @@ pub fn node_to_sexp(node: &Node, indent_level: usize) -> String {
                 source_range,
                 nodes_to_sexp(nodes, indent_level + indent_increment),
                 indent = indent_level
+            )
+        }
+        Node::Rule { source_range } => {
+            format!("{:indent$}(rule @{:?})", "", source_range, indent = indent_level)
+        }
+        Node::DisplayMath {
+            content,
+            source_range,
+        } => {
+            format!(
+                "{:indent$}(display_math @{:?}\n{:inner_indent$}\"{}\")",
+                "",
+                source_range,
+                "",
+                content.trim(),
+                indent = indent_level,
+                inner_indent = indent_level + indent_increment,
             )
         }
     }

--- a/basalt/src/note_editor/ast.rs
+++ b/basalt/src/note_editor/ast.rs
@@ -104,9 +104,7 @@ pub enum Node {
         source_range: SourceRange<usize>,
     },
     /// A horizontal rule (thematic break) rendered as a separator line.
-    Rule {
-        source_range: SourceRange<usize>,
-    },
+    Rule { source_range: SourceRange<usize> },
     /// A display math block (e.g. `$$...$$`), storing the formula content.
     DisplayMath {
         content: String,
@@ -257,7 +255,12 @@ pub fn node_to_sexp(node: &Node, indent_level: usize) -> String {
             )
         }
         Node::Rule { source_range } => {
-            format!("{:indent$}(rule @{:?})", "", source_range, indent = indent_level)
+            format!(
+                "{:indent$}(rule @{:?})",
+                "",
+                source_range,
+                indent = indent_level
+            )
         }
         Node::DisplayMath {
             content,

--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -3,7 +3,7 @@ use std::ops::ControlFlow;
 use ratatui::{
     buffer::Buffer,
     layout::{Offset, Rect},
-    style::Style,
+    style::{Color, Style},
     widgets::StatefulWidget,
 };
 use unicode_width::UnicodeWidthChar;
@@ -381,11 +381,19 @@ impl Cursor {
 #[derive(Clone, Debug, Default)]
 pub struct CursorWidget {
     offset: Offset,
+    code_block_selection_bg: Option<Color>,
 }
 
 impl CursorWidget {
     pub fn with_offset(self, offset: Offset) -> Self {
-        Self { offset }
+        Self { offset, ..self }
+    }
+
+    pub fn with_code_block_selection_bg(self, color: Option<Color>) -> Self {
+        Self {
+            code_block_selection_bg: color,
+            ..self
+        }
     }
 }
 
@@ -404,10 +412,12 @@ impl StatefulWidget for CursorWidget {
 
         match state.mode {
             CursorMode::Read => {
-                buf.set_style(
-                    Rect::new(x, y, area.width, 1),
-                    Style::default().reversed().dark_gray(),
-                );
+                let style = if let Some(bg) = self.code_block_selection_bg {
+                    Style::default().bg(bg)
+                } else {
+                    Style::default().reversed().dark_gray()
+                };
+                buf.set_style(Rect::new(x, y, area.width, 1), style);
             }
             CursorMode::Edit => {
                 buf.set_style(
@@ -445,6 +455,7 @@ mod tests {
                     &RenderStyle::Raw,
                     &Symbols::unicode(),
                     0,
+                    None, // Tests don't need syntax highlighting
                 )
                 .lines
             })
@@ -689,6 +700,7 @@ mod tests {
                     &RenderStyle::Visual,
                     &Symbols::unicode(),
                     0,
+                    None, // Tests don't need syntax highlighting
                 )
                 .lines
             })

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -14,6 +14,7 @@ use ratatui::{
 use crate::note_editor::{
     cursor::CursorWidget,
     state::{NoteEditorState, View},
+    virtual_document::VirtualSpan,
 };
 
 #[derive(Default)]
@@ -83,11 +84,34 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
         Paragraph::new(visible_lines).block(block).render(area, buf);
 
         if !state.content.is_empty() || state.is_editing() {
+            // D-13: Detect if cursor is on a highlighted code block row by checking
+            // for any span with explicit Color::Black background — code blocks are the
+            // only elements that use Color::Black as an explicit background color.
+            let is_code_block_row = {
+                let all_lines = state.virtual_document.lines();
+                let cursor_row = state.cursor.virtual_row();
+                all_lines.get(cursor_row).is_some_and(|line| {
+                    line.virtual_spans().iter().any(|span| {
+                        let s = match span {
+                            VirtualSpan::Synthetic(s) | VirtualSpan::Content(s, _) => s,
+                        };
+                        s.style.bg == Some(Color::Black)
+                    })
+                })
+            };
+
+            let selection_bg = if is_code_block_row {
+                state.syntect_selection_color()
+            } else {
+                None
+            };
+
             CursorWidget::default()
                 .with_offset(Offset {
                     x: inner_area.x as i32,
                     y: inner_area.y as i32 + meta_lines_count as i32,
                 })
+                .with_code_block_selection_bg(selection_bg)
                 .render(state.viewport().area(), buf, &mut state.cursor);
         }
 
@@ -226,8 +250,13 @@ mod tests {
 
         tests.iter().for_each(|text| {
             _ = terminal.clear();
-            let mut state =
-                NoteEditorState::new(text, "Test", Path::new("test.md"), &Symbols::unicode());
+            let mut state = NoteEditorState::new(
+                text,
+                "Test",
+                Path::new("test.md"),
+                &Symbols::unicode(),
+                None,
+            );
             terminal
                 .draw(|frame| {
                     NoteEditor::default().render(frame.area(), frame.buffer_mut(), &mut state)
@@ -264,7 +293,13 @@ mod tests {
             (
                 "read_mode_with_content",
                 Box::new(|_| {
-                    NoteEditorState::new(content, "Test", Path::new("test.md"), &Symbols::unicode())
+                    NoteEditorState::new(
+                        content,
+                        "Test",
+                        Path::new("test.md"),
+                        &Symbols::unicode(),
+                        None,
+                    )
                 }),
             ),
             (
@@ -275,6 +310,7 @@ mod tests {
                         "Test",
                         Path::new("test.md"),
                         &Symbols::unicode(),
+                        None,
                     );
                     state.set_view(View::Edit(EditMode::Source));
                     state
@@ -288,6 +324,7 @@ mod tests {
                         "Test",
                         Path::new("test.md"),
                         &Symbols::unicode(),
+                        None,
                     );
                     state.resize_viewport(area.as_size());
                     state.set_view(View::Edit(EditMode::Source));
@@ -305,6 +342,7 @@ mod tests {
                         "Test",
                         Path::new("test.md"),
                         &Symbols::unicode(),
+                        None,
                     );
                     state.resize_viewport(area.as_size());
                     state.set_view(View::Edit(EditMode::Source));
@@ -329,6 +367,7 @@ mod tests {
                         "Test",
                         Path::new("test.md"),
                         &Symbols::unicode(),
+                        None,
                     );
                     state.resize_viewport(area.as_size());
                     state.cursor_down(1);
@@ -519,8 +558,13 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
 
         tests.into_iter().for_each(|(name, content)| {
-            let mut state =
-                NoteEditorState::new(content, name, Path::new("test.md"), &Symbols::unicode());
+            let mut state = NoteEditorState::new(
+                content,
+                name,
+                Path::new("test.md"),
+                &Symbols::unicode(),
+                None,
+            );
             _ = terminal.clear();
             terminal
                 .draw(|frame| {

--- a/basalt/src/note_editor/parser.rs
+++ b/basalt/src/note_editor/parser.rs
@@ -65,12 +65,21 @@ impl<'a> Parser<'a> {
         let mut result = Vec::new();
         let mut state = ParserState::default();
 
-        while let Some((event, _)) = self.next() {
+        while let Some((event, source_range)) = self.next() {
             match event {
                 Event::Start(tag) if Self::is_container_tag(&tag) => {
                     if let Some(node) = self.parse_container(tag, &mut state) {
                         result.push(node);
                     }
+                }
+                Event::Rule => {
+                    result.push(Node::Rule { source_range });
+                }
+                Event::DisplayMath(content) => {
+                    result.push(Node::DisplayMath {
+                        content: content.to_string(),
+                        source_range,
+                    });
                 }
                 _ => {}
             }
@@ -83,6 +92,9 @@ impl<'a> Parser<'a> {
         let mut nodes = Vec::new();
         let mut text_segments = Vec::new();
         let mut inline_styles = Vec::new();
+        // Stores display math content when DisplayMath fires inside a Paragraph container.
+        // pulldown-cmark wraps $$...$$ blocks in Start(Paragraph)/End(Paragraph).
+        let mut paragraph_display_math: Option<(String, SourceRange<usize>)> = None;
 
         match tag {
             Tag::List(Some(start)) => {
@@ -119,6 +131,17 @@ impl<'a> Parser<'a> {
                 Event::Code(text) => {
                     let text_segment = TextSegment::styled(&text, Style::Code);
                     text_segments.push(text_segment);
+                }
+
+                Event::InlineMath(text) => {
+                    let text_segment = TextSegment::styled(&text, Style::InlineMath);
+                    text_segments.push(text_segment);
+                }
+
+                // DisplayMath fires inside a Paragraph container in pulldown-cmark.
+                // Capture it so we can return Node::DisplayMath instead of Node::Paragraph.
+                Event::DisplayMath(content) => {
+                    paragraph_display_math = Some((content.to_string(), source_range));
                 }
 
                 Event::Text(text) => {
@@ -208,7 +231,18 @@ impl<'a> Parser<'a> {
                             nodes,
                             source_range,
                         }),
-                        Tag::Paragraph => Some(Node::Paragraph { text, source_range }),
+                        Tag::Paragraph => {
+                            // If this paragraph contained a display math block, return that
+                            // instead. pulldown-cmark wraps $$...$$ in a Paragraph container.
+                            if let Some((content, math_range)) = paragraph_display_math {
+                                Some(Node::DisplayMath {
+                                    content,
+                                    source_range: math_range,
+                                })
+                            } else {
+                                Some(Node::Paragraph { text, source_range })
+                            }
+                        }
                         _ => None,
                     };
                 }
@@ -381,23 +415,37 @@ mod tests {
                   - [ ] Subtask 2
                 "#},
             ),
-            // TODO: Implement horizontal rule
-            // (
-            //     "horizontal_rule",
-            //     indoc! { r#"## Horizontal rule
-            //     You can use three or more stars `***`, hyphens `---`, or underscore `___` on its own line to add a horizontal bar. You can also separate symbols using spaces.
-            //
-            //     ***
-            //     ****
-            //     * * *
-            //     ---
-            //     ----
-            //     - - -
-            //     ___
-            //     ____
-            //     _ _ _
-            //     "#},
-            // ),
+            (
+                "horizontal_rule",
+                indoc! { r#"## Horizontal rule
+                You can use three or more stars `***`, hyphens `---`, or underscore `___` on its own line to add a horizontal bar. You can also separate symbols using spaces.
+
+                ***
+                ****
+                * * *
+                ---
+                ----
+                - - -
+                ___
+                ____
+                _ _ _
+                "#},
+            ),
+            (
+                "inline_math",
+                indoc! { r#"## Math
+                Euler's identity: $e^{i\pi} + 1 = 0$ is beautiful.
+                "#},
+            ),
+            (
+                "display_math",
+                indoc! { r#"## Display Math
+
+                $$
+                \int_0^\infty e^{-x} dx = 1
+                $$
+                "#},
+            ),
             (
                 "code_blocks",
                 indoc! { r#"## Code blocks

--- a/basalt/src/note_editor/render.rs
+++ b/basalt/src/note_editor/render.rs
@@ -9,7 +9,7 @@ use crate::{
     config::Symbols,
     note_editor::{
         ast::{self, SourceRange},
-        rich_text::RichText,
+        rich_text::{self, RichText},
         text_wrap::wrap_preserve_trailing,
         virtual_document::{
             content_span, empty_virtual_line, synthetic_span, virtual_line, VirtualBlock,
@@ -115,6 +115,101 @@ fn render_raw_line<'a>(
         &RenderStyle::Raw,
         symbols,
     )
+}
+
+/// Convert a `RichText` into a list of ratatui `Span`s, one per `TextSegment`,
+/// each carrying the appropriate ratatui style for that segment's `rich_text::Style`.
+fn rich_text_to_spans(text: &rich_text::RichText) -> Vec<Span<'static>> {
+    text.segments()
+        .iter()
+        .map(|seg| {
+            let span = Span::raw(seg.content.clone());
+            match &seg.style {
+                Some(rich_text::Style::Strong) => span.bold(),
+                Some(rich_text::Style::Emphasis) => span.italic(),
+                Some(rich_text::Style::Strikethrough) => span.add_modifier(Modifier::CROSSED_OUT),
+                Some(rich_text::Style::Code) => span.fg(Color::Yellow).bg(Color::Rgb(30, 30, 30)),
+                Some(rich_text::Style::InlineMath) => span.fg(Color::Magenta).italic(),
+                None => span,
+            }
+        })
+        .collect()
+}
+
+/// Word-wrap a slice of styled `Span`s to `max_width` columns, preserving per-span
+/// styles. Each display line is a `Vec<Span<'static>>`.
+///
+/// This mirrors the wrapping logic in `text_wrap_internal` by concatenating span contents
+/// to obtain the plain-text wrap result, then re-applying styles via byte-offset mapping.
+fn wrap_styled_spans(
+    spans: &[Span<'static>],
+    max_width: usize,
+    wrap_marker: &str,
+) -> Vec<Vec<Span<'static>>> {
+    if spans.is_empty() {
+        return vec![vec![]];
+    }
+
+    // Build flat plain text and record the (start_byte, end_byte, Style) for each span.
+    let mut plain = String::new();
+    let mut span_ranges: Vec<(usize, usize, ratatui::style::Style)> = Vec::new();
+    for span in spans {
+        let start = plain.len();
+        plain.push_str(&span.content);
+        span_ranges.push((start, plain.len(), span.style));
+    }
+
+    // Wrap the plain text using the same function as `text_wrap_internal`.
+    let wrap_marker_display_width = UnicodeWidthStr::width(wrap_marker);
+    let wrapped = wrap_preserve_trailing(&plain, max_width, wrap_marker_display_width + 1);
+
+    if wrapped.is_empty() {
+        return vec![vec![]];
+    }
+
+    // Map each display line back to styled spans.
+    let mut result: Vec<Vec<Span<'static>>> = Vec::new();
+    let mut byte_cursor: usize = 0;
+    let mut span_iter_idx: usize = 0;
+
+    for line_str in &wrapped {
+        let line_bytes = line_str.len();
+        let line_end = byte_cursor + line_bytes;
+        let mut line_spans: Vec<Span<'static>> = Vec::new();
+
+        let mut pos = byte_cursor;
+        while pos < line_end && span_iter_idx < span_ranges.len() {
+            let (span_start, span_end, style) = span_ranges[span_iter_idx];
+            if span_end <= pos {
+                span_iter_idx += 1;
+                continue;
+            }
+            let chunk_start = pos.max(span_start);
+            let chunk_end = line_end.min(span_end);
+            if chunk_start < chunk_end {
+                if let Some(chunk) = plain.get(chunk_start..chunk_end) {
+                    if !chunk.is_empty() {
+                        line_spans.push(Span::styled(chunk.to_string(), style));
+                    }
+                }
+                pos = chunk_end;
+                if chunk_end >= span_end {
+                    span_iter_idx += 1;
+                }
+            } else {
+                break;
+            }
+        }
+
+        result.push(line_spans);
+        byte_cursor = line_end;
+    }
+
+    if result.is_empty() {
+        result.push(vec![]);
+    }
+
+    result
 }
 
 // # Example:
@@ -294,27 +389,86 @@ pub fn paragraph<'a>(
     let lines = match option {
         RenderStyle::Raw => render_raw(content, source_range, max_width, prefix, symbols),
         RenderStyle::Visual => {
-            let text = text.to_string();
+            let styled_spans = rich_text_to_spans(text);
+            let wrap_width = max_width;
+            let wrap_marker = symbols.wrap_marker.clone();
             let mut current_range_start = source_range.start;
+            let mut lines: Vec<VirtualLine<'a>> = Vec::new();
 
-            let mut lines = text
-                .to_string()
-                .lines()
-                .flat_map(|line| {
-                    let line_range = line_range(current_range_start, line.len(), true);
-                    current_range_start = line_range.end;
+            // Collect logical lines by splitting on '\n' within segment content.
+            // Each logical line is then word-wrapped using wrap_styled_spans which
+            // preserves per-segment styles while reproducing the same line-break
+            // positions as the original text_wrap_internal path.
+            let mut logical_line: Vec<Span<'static>> = Vec::new();
+            for span in &styled_spans {
+                let content = span.content.as_ref();
+                let parts: Vec<&str> = content.split('\n').collect();
+                for (j, part) in parts.iter().enumerate() {
+                    if !part.is_empty() {
+                        logical_line.push(Span::styled(part.to_string(), span.style));
+                    }
+                    let is_last_part = j == parts.len() - 1;
+                    if !is_last_part {
+                        // Flush current logical line (explicit '\n' in source).
+                        let display_lines =
+                            wrap_styled_spans(&logical_line, wrap_width, &wrap_marker);
+                        for (di, display_line_spans) in display_lines.iter().enumerate() {
+                            let is_wrap_continuation = di > 0;
+                            let line_byte_len: usize =
+                                display_line_spans.iter().map(|s| s.content.len()).sum();
+                            let line_range = current_range_start
+                                ..(current_range_start + line_byte_len).min(source_range.end);
+                            current_range_start += line_byte_len;
 
-                    text_wrap(
-                        &line.to_string().into(),
-                        prefix.clone(),
-                        &line_range,
-                        max_width,
-                        None,
-                        option,
-                        symbols,
-                    )
-                })
-                .collect::<Vec<_>>();
+                            let mut vspans: Vec<VirtualSpan<'a>> =
+                                vec![synthetic_span!(prefix.clone())];
+                            if is_wrap_continuation {
+                                vspans.push(synthetic_span!(Span::styled(
+                                    wrap_marker.clone(),
+                                    Style::new().black()
+                                )));
+                            }
+                            for s in display_line_spans {
+                                vspans.push(content_span!(s.clone(), line_range));
+                            }
+                            lines.push(VirtualLine::new(&vspans));
+                        }
+                        // +1 for the '\n' byte.
+                        current_range_start += 1;
+                        logical_line = Vec::new();
+                    }
+                }
+            }
+
+            // Flush the final (or only) logical line.
+            {
+                let display_lines = wrap_styled_spans(&logical_line, wrap_width, &wrap_marker);
+                for (di, display_line_spans) in display_lines.iter().enumerate() {
+                    let is_wrap_continuation = di > 0;
+                    let line_byte_len: usize =
+                        display_line_spans.iter().map(|s| s.content.len()).sum();
+                    let line_range = current_range_start
+                        ..(current_range_start + line_byte_len).min(source_range.end);
+                    current_range_start += line_byte_len;
+
+                    let mut vspans: Vec<VirtualSpan<'a>> = vec![synthetic_span!(prefix.clone())];
+                    if is_wrap_continuation {
+                        vspans.push(synthetic_span!(Span::styled(
+                            wrap_marker.clone(),
+                            Style::new().black()
+                        )));
+                    }
+                    for s in display_line_spans {
+                        vspans.push(content_span!(s.clone(), line_range));
+                    }
+                    lines.push(VirtualLine::new(&vspans));
+                }
+            }
+
+            if lines.is_empty() {
+                // Empty paragraph — push a line with just the prefix so cursor has a home.
+                lines.push(VirtualLine::new(&[synthetic_span!(prefix.clone())]));
+            }
 
             if prefix.to_string().is_empty() {
                 lines.extend([empty_virtual_line!()]);
@@ -598,6 +752,66 @@ pub fn line_range(start: usize, line_width: usize, newline: bool) -> SourceRange
     start..end
 }
 
+/// Renders a horizontal rule as a full-width separator line using the
+/// configured `symbols.horizontal_rule` character (default: "═").
+fn rule<'a>(
+    source_range: &SourceRange<usize>,
+    max_width: usize,
+    prefix: Span<'static>,
+    symbols: &Symbols,
+) -> VirtualBlock<'a> {
+    let separator = symbols
+        .horizontal_rule
+        .repeat(max_width.saturating_sub(prefix.width()));
+    let lines = vec![
+        virtual_line!([
+            synthetic_span!(prefix),
+            synthetic_span!(Span::raw(separator))
+        ]),
+        empty_virtual_line!(),
+    ];
+    VirtualBlock::new(&lines, source_range)
+}
+
+/// Renders a display math block as a three-line layout:
+/// separator line (thin "─"), formula content, separator line.
+/// Separator width matches the formula text width (not full terminal width).
+/// All lines styled in Magenta; formula is italic.
+fn display_math<'a>(
+    content: &str,
+    source_range: &SourceRange<usize>,
+    prefix: Span<'static>,
+) -> VirtualBlock<'a> {
+    let formula = content.trim();
+    let formula_width = UnicodeWidthStr::width(formula);
+    let separator = "\u{2500}".repeat(formula_width); // U+2500 BOX DRAWINGS LIGHT HORIZONTAL
+
+    let sep_span = Span::styled(separator, Style::default().fg(Color::Magenta));
+    let formula_span = Span::styled(
+        formula.to_string(),
+        Style::default()
+            .fg(Color::Magenta)
+            .add_modifier(Modifier::ITALIC),
+    );
+
+    let lines = vec![
+        virtual_line!([
+            synthetic_span!(prefix.clone()),
+            synthetic_span!(sep_span.clone())
+        ]),
+        virtual_line!([
+            synthetic_span!(prefix.clone()),
+            synthetic_span!(formula_span)
+        ]),
+        virtual_line!([
+            synthetic_span!(prefix),
+            synthetic_span!(sep_span)
+        ]),
+        empty_virtual_line!(),
+    ];
+    VirtualBlock::new(&lines, source_range)
+}
+
 // FIXME: Use options struct or similar
 #[allow(clippy::too_many_arguments)]
 pub fn block_quote<'a>(
@@ -748,5 +962,103 @@ pub fn render_node<'a>(
             option,
             symbols,
         ),
+        Rule { source_range } => rule(source_range, max_width, prefix, symbols),
+        DisplayMath {
+            content,
+            source_range,
+        } => display_math(content, source_range, prefix),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::note_editor::rich_text::{Style as RichStyle, TextSegment};
+
+    #[test]
+    fn test_rich_text_to_spans_inline_math() {
+        let text = RichText::from(vec![TextSegment::styled("E = mc^2", RichStyle::InlineMath)]);
+        let spans = rich_text_to_spans(&text);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, "E = mc^2");
+        let expected = ratatui::style::Style::default()
+            .fg(Color::Magenta)
+            .add_modifier(Modifier::ITALIC);
+        assert_eq!(spans[0].style, expected);
+    }
+
+    #[test]
+    fn test_rule_render() {
+        use crate::config::Symbols;
+        let symbols = Symbols::default();
+        let source_range = 0..3;
+        let max_width = 20;
+        let prefix = Span::raw("");
+        let block = rule(&source_range, max_width, prefix, &symbols);
+        // Block should have 2 lines: separator + empty
+        assert_eq!(block.lines.len(), 2);
+        // First line should contain the repeated horizontal_rule character
+        let first_line = &block.lines[0];
+        let content: String = first_line
+            .virtual_spans()
+            .iter()
+            .map(|s| match s {
+                VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => {
+                    span.content.to_string()
+                }
+            })
+            .collect();
+        assert!(content.contains(&symbols.horizontal_rule.repeat(20)));
+    }
+
+    fn vline_content(line: &VirtualLine<'_>) -> String {
+        line.virtual_spans()
+            .iter()
+            .map(|s| match s {
+                VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => {
+                    span.content.to_string()
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_display_math_render() {
+        let content = "\n\\int_0^\\infty e^{-x} dx = 1\n";
+        let source_range = 0..35;
+        let prefix = Span::raw("");
+        let block = display_math(content, &source_range, prefix);
+        // Block should have 4 lines: separator + formula + separator + empty
+        assert_eq!(block.lines.len(), 4);
+
+        // First line (separator): contains "─" repeated to formula width
+        let sep_line = vline_content(&block.lines[0]);
+        assert!(sep_line.contains("\u{2500}"), "Separator should use U+2500");
+        assert!(!sep_line.contains('═'), "Separator should NOT use horizontal_rule char");
+
+        // Second line (formula): contains trimmed formula text
+        let formula_line = vline_content(&block.lines[1]);
+        assert!(formula_line.contains("\\int_0^\\infty"));
+        assert!(!formula_line.starts_with('\n'), "Formula should be trimmed");
+
+        // Third line (separator): same as first
+        let sep_line_2 = vline_content(&block.lines[2]);
+        assert_eq!(sep_line, sep_line_2, "Top and bottom separators should match");
+
+        // Verify formula span has Magenta + ITALIC
+        let formula_vspan = block.lines[1]
+            .virtual_spans()
+            .iter()
+            .find(|s| match s {
+                VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => {
+                    span.content.contains("\\int")
+                }
+            })
+            .expect("formula span not found");
+        let formula_rspan = match formula_vspan {
+            VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => span,
+        };
+        assert_eq!(formula_rspan.style.fg, Some(Color::Magenta));
+        assert!(formula_rspan.style.add_modifier.contains(Modifier::ITALIC));
     }
 }

--- a/basalt/src/note_editor/render.rs
+++ b/basalt/src/note_editor/render.rs
@@ -6,6 +6,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
+    app::SyntectContext,
     config::Symbols,
     note_editor::{
         ast::{self, SourceRange},
@@ -481,16 +482,17 @@ pub fn paragraph<'a>(
     VirtualBlock::new(&lines, source_range)
 }
 
+// FIXME: Use options struct or similar
+#[allow(clippy::too_many_arguments)]
 pub fn code_block<'a>(
     content: &str,
     prefix: Span<'static>,
-    // TODO: Add lang support
-    // Ref: https://github.com/erikjuhani/basalt/issues/96
-    _lang: &Option<String>,
+    lang: &Option<String>,
     text: &RichText,
     source_range: &SourceRange<usize>,
     max_width: usize,
     option: &RenderStyle,
+    syntect_ctx: Option<&SyntectContext>,
 ) -> VirtualBlock<'a> {
     let lines = match option {
         RenderStyle::Raw => {
@@ -522,34 +524,137 @@ pub fn code_block<'a>(
         }
         RenderStyle::Visual => {
             let text = text.to_string();
+            let available_width = max_width.saturating_sub(prefix.width());
 
-            let padding_line = virtual_line!([
-                synthetic_span!(prefix.clone()),
-                synthetic_span!(" "
-                    .repeat(max_width.saturating_sub(prefix.width()))
-                    .bg(Color::Black))
-            ]);
-
-            let mut current_range_start = source_range.start;
-
-            let mut lines = vec![padding_line.clone()];
-            lines.extend(text.lines().map(|line| {
-                let source_range = line_range(current_range_start, line.len(), true);
-                current_range_start = source_range.end;
-
+            // Top padding line with optional language label (D-10)
+            let padding_line = if let Some(ref lang_str) = lang {
+                let label = lang_str.as_str();
+                let label_display: String = if label.chars().count() <= available_width {
+                    label.to_string()
+                } else {
+                    label
+                        .char_indices()
+                        .take_while(|(i, _)| *i < available_width)
+                        .map(|(_, c)| c)
+                        .collect()
+                };
+                let pad_count =
+                    available_width.saturating_sub(UnicodeWidthStr::width(label_display.as_str()));
                 virtual_line!([
                     synthetic_span!(prefix.clone()),
-                    synthetic_span!(Span::styled(" ", Style::new().bg(Color::Black))),
-                    content_span!(line.to_string().bg(Color::Black), source_range),
-                    synthetic_span!(" "
-                        .repeat(
-                            max_width
-                                .saturating_sub(prefix.width() + line.chars().count())
-                                .saturating_sub(1)
-                        )
-                        .bg(Color::Black)),
+                    synthetic_span!(Span::styled(
+                        " ".repeat(pad_count),
+                        Style::default().bg(Color::Black)
+                    )),
+                    synthetic_span!(Span::styled(
+                        label_display,
+                        Style::default().fg(Color::DarkGray).bg(Color::Black)
+                    )),
                 ])
-            }));
+            } else {
+                virtual_line!([
+                    synthetic_span!(prefix.clone()),
+                    synthetic_span!(" ".repeat(available_width).bg(Color::Black)),
+                ])
+            };
+
+            // Determine syntax for highlighting; pair syntax with its context so
+            // the type system guarantees both are present together.
+            let highlight_pair = syntect_ctx.and_then(|ctx| {
+                lang.as_deref()
+                    .and_then(|l| ctx.syntax_set.find_syntax_by_token(l))
+                    .map(|syntax| (syntax, ctx))
+            });
+
+            let mut current_range_start = source_range.start;
+            let mut lines = vec![padding_line.clone()];
+
+            match highlight_pair {
+                Some((syntax, ctx)) => {
+                    // Highlighted path (D-09, CODE-02)
+                    use syntect::easy::HighlightLines;
+                    use syntect::util::LinesWithEndings;
+
+                    let mut highlighter = HighlightLines::new(syntax, &ctx.theme);
+
+                    for line in LinesWithEndings::from(&text) {
+                        let line_trimmed = line.trim_end_matches('\n');
+                        let source_range =
+                            line_range(current_range_start, line_trimmed.len(), true);
+                        current_range_start = source_range.end;
+
+                        // Get highlighted tokens; fallback to monochrome on error
+                        let ranges = highlighter
+                            .highlight_line(line, &ctx.syntax_set)
+                            .unwrap_or_else(|_| {
+                                vec![(syntect::highlighting::Style::default(), line)]
+                            });
+
+                        let mut token_spans: Vec<VirtualSpan> = Vec::new();
+                        token_spans.push(synthetic_span!(prefix.clone()));
+                        token_spans.push(synthetic_span!(Span::styled(
+                            " ",
+                            Style::default().bg(Color::Black)
+                        )));
+
+                        for (style, token) in &ranges {
+                            let token_text = token.trim_end_matches('\n');
+                            if token_text.is_empty() {
+                                continue;
+                            }
+                            let fg = Color::Rgb(
+                                style.foreground.r,
+                                style.foreground.g,
+                                style.foreground.b,
+                            );
+                            token_spans.push(synthetic_span!(Span::styled(
+                                token_text.to_string(),
+                                Style::default().fg(fg).bg(Color::Black)
+                            )));
+                        }
+
+                        // Right padding to fill the code block width
+                        let right_pad = max_width
+                            .saturating_sub(prefix.width() + UnicodeWidthStr::width(line_trimmed))
+                            .saturating_sub(1);
+                        token_spans.push(synthetic_span!(Span::styled(
+                            " ".repeat(right_pad),
+                            Style::default().bg(Color::Black)
+                        )));
+
+                        // D-12: Zero-width content anchor so has_content() returns true,
+                        // allowing cursor navigation through highlighted code lines.
+                        // Padding lines (top/bottom) remain synthetic-only and non-navigable.
+                        token_spans
+                            .push(content_span!("".to_string().bg(Color::Black), source_range));
+
+                        lines.push(VirtualLine::new(&token_spans));
+                    }
+                }
+                None => {
+                    // Monochrome fallback path (D-11, CODE-03)
+                    lines.extend(text.lines().map(|line| {
+                        let source_range = line_range(current_range_start, line.len(), true);
+                        current_range_start = source_range.end;
+
+                        virtual_line!([
+                            synthetic_span!(prefix.clone()),
+                            synthetic_span!(Span::styled(" ", Style::new().bg(Color::Black))),
+                            content_span!(line.to_string().bg(Color::Black), source_range),
+                            synthetic_span!(" "
+                                .repeat(
+                                    max_width
+                                        .saturating_sub(
+                                            prefix.width() + UnicodeWidthStr::width(line),
+                                        )
+                                        .saturating_sub(1)
+                                )
+                                .bg(Color::Black)),
+                        ])
+                    }));
+                }
+            }
+
             lines.extend([padding_line]);
             lines.extend([empty_virtual_line!()]);
             lines
@@ -570,6 +675,7 @@ pub fn list<'a>(
     option: &RenderStyle,
     symbols: &Symbols,
     list_depth: usize,
+    syntect_ctx: Option<&SyntectContext>,
 ) -> VirtualBlock<'a> {
     let lines = match option {
         RenderStyle::Raw => render_raw(content, source_range, max_width, prefix, symbols),
@@ -589,6 +695,7 @@ pub fn list<'a>(
                         option,
                         symbols,
                         list_depth,
+                        syntect_ctx,
                     )
                     .lines
                 })
@@ -616,6 +723,7 @@ pub fn task<'a>(
     option: &RenderStyle,
     symbols: &Symbols,
     list_depth: usize,
+    syntect_ctx: Option<&SyntectContext>,
 ) -> VirtualBlock<'a> {
     let lines = match option {
         RenderStyle::Raw => render_raw(content, source_range, max_width, prefix, symbols),
@@ -666,6 +774,7 @@ pub fn task<'a>(
                     option,
                     symbols,
                     list_depth + 1,
+                    syntect_ctx,
                 )
                 .lines
             }));
@@ -689,6 +798,7 @@ pub fn item<'a>(
     option: &RenderStyle,
     symbols: &Symbols,
     list_depth: usize,
+    syntect_ctx: Option<&SyntectContext>,
 ) -> VirtualBlock<'a> {
     let lines = match option {
         RenderStyle::Raw => render_raw(content, source_range, max_width, prefix, symbols),
@@ -734,6 +844,7 @@ pub fn item<'a>(
                     option,
                     symbols,
                     list_depth + 1,
+                    syntect_ctx,
                 )
                 .lines
             }));
@@ -803,10 +914,7 @@ fn display_math<'a>(
             synthetic_span!(prefix.clone()),
             synthetic_span!(formula_span)
         ]),
-        virtual_line!([
-            synthetic_span!(prefix),
-            synthetic_span!(sep_span)
-        ]),
+        virtual_line!([synthetic_span!(prefix), synthetic_span!(sep_span)]),
         empty_virtual_line!(),
     ];
     VirtualBlock::new(&lines, source_range)
@@ -827,6 +935,7 @@ pub fn block_quote<'a>(
     max_width: usize,
     option: &RenderStyle,
     symbols: &Symbols,
+    syntect_ctx: Option<&SyntectContext>,
 ) -> VirtualBlock<'a> {
     let lines = match option {
         RenderStyle::Raw => render_raw(content, source_range, max_width, prefix, symbols),
@@ -842,6 +951,7 @@ pub fn block_quote<'a>(
                     option,
                     symbols,
                     0,
+                    syntect_ctx,
                 )
                 .lines;
                 if prefix.to_string().is_empty() && i != nodes.len().saturating_sub(1) {
@@ -858,6 +968,8 @@ pub fn block_quote<'a>(
     VirtualBlock::new(&lines, source_range)
 }
 
+// FIXME: Use options struct or similar
+#[allow(clippy::too_many_arguments)]
 pub fn render_node<'a>(
     content: String,
     node: &ast::Node,
@@ -866,6 +978,7 @@ pub fn render_node<'a>(
     option: &RenderStyle,
     symbols: &Symbols,
     list_depth: usize,
+    syntect_ctx: Option<&SyntectContext>,
 ) -> VirtualBlock<'a> {
     use ast::Node::*;
     match node {
@@ -904,6 +1017,7 @@ pub fn render_node<'a>(
             source_range,
             max_width,
             option,
+            syntect_ctx,
         ),
         List {
             nodes,
@@ -917,6 +1031,7 @@ pub fn render_node<'a>(
             option,
             symbols,
             list_depth,
+            syntect_ctx,
         ),
         Item {
             kind,
@@ -932,6 +1047,7 @@ pub fn render_node<'a>(
             option,
             symbols,
             list_depth,
+            syntect_ctx,
         ),
         Task {
             kind,
@@ -947,6 +1063,7 @@ pub fn render_node<'a>(
             option,
             symbols,
             list_depth,
+            syntect_ctx,
         ),
         BlockQuote {
             kind,
@@ -961,6 +1078,7 @@ pub fn render_node<'a>(
             max_width,
             option,
             symbols,
+            syntect_ctx,
         ),
         Rule { source_range } => rule(source_range, max_width, prefix, symbols),
         DisplayMath {
@@ -1034,7 +1152,10 @@ mod tests {
         // First line (separator): contains "─" repeated to formula width
         let sep_line = vline_content(&block.lines[0]);
         assert!(sep_line.contains("\u{2500}"), "Separator should use U+2500");
-        assert!(!sep_line.contains('═'), "Separator should NOT use horizontal_rule char");
+        assert!(
+            !sep_line.contains('═'),
+            "Separator should NOT use horizontal_rule char"
+        );
 
         // Second line (formula): contains trimmed formula text
         let formula_line = vline_content(&block.lines[1]);
@@ -1043,7 +1164,10 @@ mod tests {
 
         // Third line (separator): same as first
         let sep_line_2 = vline_content(&block.lines[2]);
-        assert_eq!(sep_line, sep_line_2, "Top and bottom separators should match");
+        assert_eq!(
+            sep_line, sep_line_2,
+            "Top and bottom separators should match"
+        );
 
         // Verify formula span has Magenta + ITALIC
         let formula_vspan = block.lines[1]
@@ -1060,5 +1184,136 @@ mod tests {
         };
         assert_eq!(formula_rspan.style.fg, Some(Color::Magenta));
         assert!(formula_rspan.style.add_modifier.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn test_syntect_context_init() {
+        use crate::app::SyntectContext;
+        // SyntectContext::new() should not panic
+        let ctx = SyntectContext::new();
+        // Should find Rust syntax
+        assert!(ctx.syntax_set.find_syntax_by_token("rust").is_some());
+        // Should find Python syntax
+        assert!(ctx.syntax_set.find_syntax_by_token("py").is_some());
+        // Unknown should return None, not panic
+        assert!(ctx
+            .syntax_set
+            .find_syntax_by_token("nonexistent_lang_xyz")
+            .is_none());
+        // Plain text should always be present
+        let _pt = ctx.syntax_set.find_syntax_plain_text();
+    }
+
+    #[test]
+    fn test_code_block_syntect_visual() {
+        use crate::app::SyntectContext;
+
+        let ctx = SyntectContext::new();
+        let content = "fn main() {}";
+        let text = RichText::from(vec![TextSegment::plain(content)]);
+        let source_range = 0..12;
+        let prefix = Span::raw("");
+        let block = code_block(
+            content,
+            prefix,
+            &Some("rust".to_string()),
+            &text,
+            &source_range,
+            40,
+            &RenderStyle::Visual,
+            Some(&ctx),
+        );
+        // Should not panic; should have lines: top padding + content + bottom padding + empty
+        assert!(
+            block.lines.len() >= 4,
+            "Expected at least 4 lines (top pad + content + bottom pad + empty), got {}",
+            block.lines.len()
+        );
+        // Top padding line should contain "rust" label
+        let top_line_content: String = block.lines[0]
+            .virtual_spans()
+            .iter()
+            .map(|s| match s {
+                VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => {
+                    span.content.to_string()
+                }
+            })
+            .collect();
+        assert!(
+            top_line_content.contains("rust"),
+            "Top padding line should contain language label"
+        );
+    }
+
+    #[test]
+    fn test_code_block_unknown_lang() {
+        use crate::app::SyntectContext;
+
+        let ctx = SyntectContext::new();
+        let content = "some code here";
+        let text = RichText::from(vec![TextSegment::plain(content)]);
+        let source_range = 0..14;
+        let prefix = Span::raw("");
+        // Should not panic with unknown language — falls back to monochrome (D-11)
+        let block = code_block(
+            content,
+            prefix,
+            &Some("unknownlang123".to_string()),
+            &text,
+            &source_range,
+            40,
+            &RenderStyle::Visual,
+            Some(&ctx),
+        );
+        assert!(block.lines.len() >= 4);
+        // Top padding line should still show the unknown lang label
+        let top_content: String = block.lines[0]
+            .virtual_spans()
+            .iter()
+            .map(|s| match s {
+                VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => {
+                    span.content.to_string()
+                }
+            })
+            .collect();
+        assert!(top_content.contains("unknownlang123"));
+    }
+
+    #[test]
+    fn test_code_block_no_lang() {
+        use crate::app::SyntectContext;
+
+        let ctx = SyntectContext::new();
+        let content = "plain code";
+        let text = RichText::from(vec![TextSegment::plain(content)]);
+        let source_range = 0..10;
+        let prefix = Span::raw("");
+        let block = code_block(
+            content,
+            prefix,
+            &None,
+            &text,
+            &source_range,
+            40,
+            &RenderStyle::Visual,
+            Some(&ctx),
+        );
+        assert!(block.lines.len() >= 4);
+        // Top padding line should NOT contain any language label text
+        let top_content: String = block.lines[0]
+            .virtual_spans()
+            .iter()
+            .map(|s| match s {
+                VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => {
+                    span.content.to_string()
+                }
+            })
+            .collect();
+        // Should be all spaces (padding) — no alphabetic content
+        assert!(
+            !top_content.chars().any(|c| c.is_alphabetic()),
+            "No lang label should appear when lang is None, got: {:?}",
+            top_content
+        );
     }
 }

--- a/basalt/src/note_editor/rich_text.rs
+++ b/basalt/src/note_editor/rich_text.rs
@@ -9,6 +9,8 @@ pub enum Style {
     Emphasis,
     Strong,
     Strikethrough,
+    /// Inline math style (e.g. `$formula$`).
+    InlineMath,
 }
 
 impl fmt::Display for Style {
@@ -18,6 +20,7 @@ impl fmt::Display for Style {
             Style::Emphasis => write!(f, "Emphasis"),
             Style::Strong => write!(f, "Strong"),
             Style::Strikethrough => write!(f, "Strikethrough"),
+            Style::InlineMath => write!(f, "InlineMath"),
         }
     }
 }

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__editor__tests__code_blocks.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__editor__tests__code_blocks.snap
@@ -1,5 +1,6 @@
 ---
 source: basalt/src/note_editor/editor.rs
+assertion_line: 550
 expression: terminal.backend()
 ---
 "╭──────────────────────────────────────────────────────────────────────────────╮"
@@ -10,9 +11,9 @@ expression: terminal.backend()
 "│ ──────────────────────────────────────────────────────────────────────────── │"
 "│ To format code as a block, enclose it with three backticks or three tildes.  │"
 "│                                                                              │"
-"│                                                                              │"
+"│                                                                           md │"
 "│  cd ~/Desktop                                                                │"
-"│                                                                              │"
+"│                                                                           md │"
 "│                                                                              │"
 "│ You can also create a code block by indenting the text using Tab or 4 blank  │"
 "│ ⤷ spaces.                                                                    │"

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__editor__tests__code_syntax_highlighting_in_blocks.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__editor__tests__code_syntax_highlighting_in_blocks.snap
@@ -1,5 +1,6 @@
 ---
 source: basalt/src/note_editor/editor.rs
+assertion_line: 550
 expression: terminal.backend()
 ---
 "╭──────────────────────────────────────────────────────────────────────────────╮"
@@ -11,13 +12,13 @@ expression: terminal.backend()
 "│ You can add syntax highlighting to a code block, by adding a language code   │"
 "│ ⤷ after the first set of backticks.                                          │"
 "│                                                                              │"
-"│                                                                              │"
+"│                                                                           js │"
 "│  function fancyAlert(arg) {                                                  │"
 "│    if(arg) {                                                                 │"
 "│      $.facebox({div:'#foo'})                                                 │"
 "│    }                                                                         │"
 "│  }                                                                           │"
-"│                                                                              │"
+"│                                                                           js │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__editor__tests__rendered_markdown_view-9.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__editor__tests__rendered_markdown_view-9.snap
@@ -1,5 +1,6 @@
 ---
 source: basalt/src/note_editor/editor.rs
+assertion_line: 241
 expression: terminal.backend()
 ---
 "╭──────────────────────────────────────────────────────────────────────────────╮"
@@ -11,13 +12,13 @@ expression: terminal.backend()
 "│ You can add syntax highlighting to a code block, by adding a language code   │"
 "│ ⤷ after the first set of backticks.                                          │"
 "│                                                                              │"
-"│                                                                              │"
+"│                                                                           js │"
 "│  function fancyAlert(arg) {                                                  │"
 "│    if(arg) {                                                                 │"
 "│      $.facebox({div:'#foo'})                                                 │"
 "│    }                                                                         │"
 "│  }                                                                           │"
-"│                                                                              │"
+"│                                                                           js │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__display_math.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__display_math.snap
@@ -1,5 +1,6 @@
 ---
 source: basalt/src/note_editor/parser.rs
+assertion_line: 481
 expression: "format!(\"{}\\n ---\\n\\n{}\", text, ast::nodes_to_sexp(&from_str(text), 0))"
 ---
 ## Display Math

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__display_math.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__display_math.snap
@@ -1,0 +1,16 @@
+---
+source: basalt/src/note_editor/parser.rs
+expression: "format!(\"{}\\n ---\\n\\n{}\", text, ast::nodes_to_sexp(&from_str(text), 0))"
+---
+## Display Math
+
+$$
+\int_0^\infty e^{-x} dx = 1
+$$
+
+ ---
+
+(heading H2 @0..16
+  "Display Math")
+(display_math @17..50
+  "\int_0^\infty e^{-x} dx = 1")

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__horizontal_rule.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__horizontal_rule.snap
@@ -1,0 +1,38 @@
+---
+source: basalt/src/note_editor/parser.rs
+expression: "format!(\"{}\\n ---\\n\\n{}\", text, ast::nodes_to_sexp(&from_str(text), 0))"
+---
+## Horizontal rule
+You can use three or more stars `***`, hyphens `---`, or underscore `___` on its own line to add a horizontal bar. You can also separate symbols using spaces.
+
+***
+****
+* * *
+---
+----
+- - -
+___
+____
+_ _ _
+
+ ---
+
+(heading H2 @0..19
+  "Horizontal rule")
+(paragraph @19..178
+  "You can use three or more stars "
+  (Code "***")
+  ", hyphens "
+  (Code "---")
+  ", or underscore "
+  (Code "___")
+  " on its own line to add a horizontal bar. You can also separate symbols using spaces.")
+(rule @179..183)
+(rule @183..188)
+(rule @188..194)
+(rule @194..198)
+(rule @198..203)
+(rule @203..209)
+(rule @209..213)
+(rule @213..218)
+(rule @218..224)

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__horizontal_rule.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__horizontal_rule.snap
@@ -1,5 +1,6 @@
 ---
 source: basalt/src/note_editor/parser.rs
+assertion_line: 481
 expression: "format!(\"{}\\n ---\\n\\n{}\", text, ast::nodes_to_sexp(&from_str(text), 0))"
 ---
 ## Horizontal rule

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__inline_math.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__inline_math.snap
@@ -1,0 +1,15 @@
+---
+source: basalt/src/note_editor/parser.rs
+expression: "format!(\"{}\\n ---\\n\\n{}\", text, ast::nodes_to_sexp(&from_str(text), 0))"
+---
+## Math
+Euler's identity: $e^{i\pi} + 1 = 0$ is beautiful.
+
+ ---
+
+(heading H2 @0..8
+  "Math")
+(paragraph @8..59
+  "Euler's identity: "
+  (InlineMath "e^{i\pi} + 1 = 0")
+  " is beautiful.")

--- a/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__inline_math.snap
+++ b/basalt/src/note_editor/snapshots/basalt_tui__note_editor__parser__tests__inline_math.snap
@@ -1,5 +1,6 @@
 ---
 source: basalt/src/note_editor/parser.rs
+assertion_line: 481
 expression: "format!(\"{}\\n ---\\n\\n{}\", text, ast::nodes_to_sexp(&from_str(text), 0))"
 ---
 ## Math

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -8,6 +8,7 @@ use std::{
 use ratatui::layout::Size;
 
 use crate::{
+    app::SyntectContext,
     config::Symbols,
     note_editor::{
         ast::{self},
@@ -71,7 +72,13 @@ pub struct NoteEditorState<'a> {
 }
 
 impl<'a> NoteEditorState<'a> {
-    pub fn new(content: &str, filename: &str, filepath: &Path, symbols: &Symbols) -> Self {
+    pub fn new(
+        content: &str,
+        filename: &str,
+        filepath: &Path,
+        symbols: &Symbols,
+        syntect_ctx: Option<&SyntectContext>,
+    ) -> Self {
         let ast_nodes = parser::from_str(content);
         let content = content.to_string();
         Self {
@@ -81,7 +88,7 @@ impl<'a> NoteEditorState<'a> {
             cursor: Cursor::default(),
             viewport: Viewport::default(),
             symbols: symbols.clone(),
-            virtual_document: VirtualDocument::new(symbols),
+            virtual_document: VirtualDocument::new(symbols, syntect_ctx),
             filename: filename.to_string(),
             filepath: filepath.to_path_buf(),
             ast_nodes,
@@ -238,6 +245,10 @@ impl<'a> NoteEditorState<'a> {
 
     pub fn active(&self) -> bool {
         self.active
+    }
+
+    pub fn syntect_selection_color(&self) -> Option<ratatui::style::Color> {
+        self.virtual_document.syntect_selection_color()
     }
 
     pub fn current_block(&self) -> usize {
@@ -579,8 +590,13 @@ mod tests {
     fn test_viewport_scrolls_with_cursor_in_edit_mode() {
         let content = "# Title\n\nLine 1\n\nLine 2\n\nLine 3\n\nLine 4\n\nLine 5\n";
 
-        let mut state =
-            NoteEditorState::new(content, "test", Path::new("test.md"), &Symbols::unicode());
+        let mut state = NoteEditorState::new(
+            content,
+            "test",
+            Path::new("test.md"),
+            &Symbols::unicode(),
+            None,
+        );
         state.resize_viewport(Size::new(40, 4));
 
         state.cursor_down(2);

--- a/basalt/src/note_editor/virtual_document.rs
+++ b/basalt/src/note_editor/virtual_document.rs
@@ -6,6 +6,7 @@ use std::{
 use ratatui::text::{Line, Span};
 
 use crate::{
+    app::SyntectContext,
     config::Symbols,
     note_editor::{
         ast::{self, SourceRange},
@@ -171,6 +172,7 @@ impl<'a> VirtualBlock<'a> {
 #[derive(Clone, Debug, Default)]
 pub struct VirtualDocument<'a> {
     symbols: Symbols,
+    syntect_ctx: Option<SyntectContext>,
     meta: Vec<VirtualLine<'a>>,
     blocks: Vec<VirtualBlock<'a>>,
     lines: Vec<VirtualLine<'a>>,
@@ -178,9 +180,10 @@ pub struct VirtualDocument<'a> {
 }
 
 impl<'a> VirtualDocument<'a> {
-    pub fn new(symbols: &Symbols) -> Self {
+    pub fn new(symbols: &Symbols, syntect_ctx: Option<&SyntectContext>) -> Self {
         Self {
             symbols: symbols.clone(),
+            syntect_ctx: syntect_ctx.cloned(),
             ..Default::default()
         }
     }
@@ -202,6 +205,12 @@ impl<'a> VirtualDocument<'a> {
 
     pub fn get_block(&self, block_idx: usize) -> Option<(usize, &VirtualBlock<'_>)> {
         self.blocks().get(block_idx).map(|block| (block_idx, block))
+    }
+
+    pub fn syntect_selection_color(&self) -> Option<ratatui::style::Color> {
+        self.syntect_ctx
+            .as_ref()
+            .and_then(|ctx| ctx.selection_color)
     }
 
     // FIXME: Refactor. Too many arguments.
@@ -260,6 +269,7 @@ impl<'a> VirtualDocument<'a> {
                         &RenderStyle::Raw,
                         &self.symbols,
                         0,
+                        None, // No syntax highlighting in Raw/Edit mode
                     )
                 } else {
                     render_node(
@@ -270,6 +280,7 @@ impl<'a> VirtualDocument<'a> {
                         &RenderStyle::Visual,
                         &self.symbols,
                         0,
+                        self.syntect_ctx.as_ref(), // Pass syntect context for Visual rendering
                     )
                 };
                 let block_lines = block.lines.clone();


### PR DESCRIPTION
- Add inline style tracking via style_stack
- Implement style-to-modifier mapping in text_to_spans
- Add rich_text_to_spans helper and fix paragraph branch
- Fix item and task branches, add wrap_styled_spans
- Add Rule, InlineMath, DisplayMath to parser and AST
- Add InlineMath arm to rich_text_to_spans
- Add rule() and display_math() render functions