### PR TITLE
Polish landing page and surface devlog in the site chrome

### DIFF
--- a/site/sass/_components.scss
+++ b/site/sass/_components.scss
@@ -80,11 +80,6 @@
   overflow: hidden;
   font-family: var(--font-mono);
 }
-.splash__gif {
-  margin: 1.6rem auto 1.6rem;
-  max-width: 60rem;
-}
-
 /* GIF swap (theme-aware) */
 .gif {
   display: block;
@@ -100,6 +95,67 @@
 }
 :root[data-theme="dark"]  .gif .gif--light { display: none; }
 :root[data-theme="light"] .gif .gif--dark  { display: none; }
+
+.splash__gif {
+  margin: 1.6rem auto;
+  max-width: 60rem;
+}
+
+.splash__devlog {
+  max-width: 60rem;
+  margin: 2.2rem auto 0;
+}
+.splash__devlog-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.splash__devlog-eyebrow {
+  color: var(--fg-dim);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.splash__devlog-all {
+  color: var(--fg-dim);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+.splash__devlog-all:hover { color: var(--accent); }
+.splash__devlog-card {
+  display: block;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-soft);
+  padding: 0.9rem 1.1rem;
+  text-decoration: none;
+  color: var(--fg);
+  transition: border-color 100ms, color 100ms;
+}
+.splash__devlog-card:hover { border-color: var(--accent); text-decoration: none; }
+.splash__devlog-meta {
+  color: var(--fg-dim);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: flex;
+  gap: 0.9rem;
+  align-items: baseline;
+  margin-bottom: 0.25rem;
+}
+.splash__devlog-title {
+  color: var(--accent);
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin-bottom: 0.3rem;
+}
+.splash__devlog-excerpt {
+  color: var(--fg-dim);
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
 
 /* Landing hero */
 .hero {
@@ -133,22 +189,55 @@
 }
 
 .install {
-  display: grid;
-  gap: 0.5rem;
-  margin: 1.2rem 0 1.8rem;
+  max-width: 60rem;
+  margin: 1.2rem auto 1.8rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-soft);
+  overflow: hidden;
 }
-.install__row {
+.install__tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.install__tab {
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--border);
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  padding: 0.45rem 1rem;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  transition: color 100ms, background 100ms;
+}
+.install__tab:last-child { border-right: 0; }
+.install__tab:hover { color: var(--fg); }
+.install__tab[aria-selected="true"] {
+  color: var(--accent);
+  background: var(--bg-soft);
+  box-shadow: inset 0 -1px 0 var(--bg-soft);
+}
+.install__pane {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  background: var(--bg-soft);
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  padding: 0.5rem 0.9rem;
+  gap: 0.6rem;
+  padding: 0.7rem 0.9rem;
   font-family: var(--font-mono);
 }
-.install__label { color: var(--fg-dim); min-width: 4rem; font-size: 0.85rem; }
-.install__cmd   { color: var(--code); flex: 1; overflow-x: auto; white-space: nowrap; }
+.install__pane[hidden] { display: none; }
+.install__prompt { color: var(--fg-dim); }
+.install__cmd {
+  color: var(--code);
+  background: transparent;
+  padding: 0;
+  flex: 1;
+  overflow-x: auto;
+  white-space: nowrap;
+}
 .install__copy {
   background: transparent;
   border: 1px solid var(--border);
@@ -157,6 +246,7 @@
   font-size: 0.75rem;
   padding: 0.15rem 0.55rem;
   cursor: pointer;
+  border-radius: 3px;
 }
 .install__copy:hover { color: var(--accent); border-color: var(--accent); }
 
@@ -244,6 +334,7 @@
 .callout-title   { color: var(--accent); font-weight: 500; letter-spacing: 0.05em; text-transform: uppercase; font-size: 0.8rem; margin-bottom: 0.3rem; }
 
 /* Devlog */
+.sidebar__date { color: var(--fg-dim); font-variant-numeric: tabular-nums; margin-right: 0.35em; }
 .article--devlog { max-width: var(--max-reading-width); margin: 0 auto; }
 .article--devlog .article__crumb a { color: var(--fg-dim); text-decoration: none; }
 .article--devlog .article__crumb a:hover { color: var(--accent); }

--- a/site/static/main.js
+++ b/site/static/main.js
@@ -27,6 +27,24 @@
     });
   });
 
+  // ── install tabs ──────────────────────────────────────────────────────────
+  document.querySelectorAll('[data-install]').forEach(function (root) {
+    var tabs = root.querySelectorAll('[data-install-tab]');
+    var panes = root.querySelectorAll('[data-install-pane]');
+    tabs.forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        var name = tab.getAttribute('data-install-tab');
+        tabs.forEach(function (t) {
+          t.setAttribute('aria-selected', t === tab ? 'true' : 'false');
+        });
+        panes.forEach(function (p) {
+          if (p.getAttribute('data-install-pane') === name) p.removeAttribute('hidden');
+          else p.setAttribute('hidden', '');
+        });
+      });
+    });
+  });
+
   // ── help modal ────────────────────────────────────────────────────────────
   var modal = document.getElementById('help-modal');
   function openModal() { if (modal) { modal.dataset.open = 'true'; modal.setAttribute('aria-hidden', 'false'); } }

--- a/site/templates/devlog-post.html
+++ b/site/templates/devlog-post.html
@@ -3,7 +3,8 @@
 {% block description %}{{ page.description | default(value=config.description) }}{% endblock %}
 
 {% block body %}
-<main class="shell shell--plain">
+<main class="shell shell--no-toc">
+  {% include "partials/devlog-sidebar.html" %}
   <article class="article article--devlog">
     <div class="article__crumb">
       <a href="{{ get_url(path='@/devlog/_index.md') }}">DEVLOG</a>

--- a/site/templates/devlog.html
+++ b/site/templates/devlog.html
@@ -2,7 +2,8 @@
 {% block title %}devlog — {{ config.title }}{% endblock %}
 
 {% block body %}
-<main class="shell shell--plain">
+<main class="shell shell--no-toc">
+  {% include "partials/devlog-sidebar.html" %}
   <article class="article article--devlog">
     <div class="article__crumb">DEVLOG</div>
     <h1>{{ section.title }}</h1>

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -17,10 +17,6 @@
       <span class="splash__title">
 ⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅
       </span>
-      <span class="splash__heading">
-TUI Application to manage Obsidian
-vaults and notes directly from the terminal.
-      </span>
 <a style="font-weight: 600" href="{{ get_url(path='@/changelog.md') }}">v{{ config.extra.basalt_version }}</a>
 <br/>
    </span>
@@ -32,26 +28,51 @@ vaults and notes directly from the terminal.
       </div>
     {% endif %}
 
-    <div class="install">
-      {% for row in section.extra.install_commands %}
-        <div class="install__row">
-          <span class="install__label">{{ row.label }}</span>
-          <span class="install__cmd">$ {{ row.cmd }}</span>
-          <button class="install__copy" type="button" data-copy="{{ row.cmd }}">copy</button>
+    {% if section.extra.install_commands %}
+      <div class="install" data-install>
+        <div class="install__tabs" role="tablist">
+          {% for row in section.extra.install_commands %}
+            <button class="install__tab" type="button" role="tab"
+                    data-install-tab="{{ row.label }}"
+                    aria-selected="{% if loop.first %}true{% else %}false{% endif %}">
+              {{ row.label }}
+            </button>
+          {% endfor %}
         </div>
-      {% endfor %}
-    </div>
+        {% for row in section.extra.install_commands %}
+          <div class="install__pane" data-install-pane="{{ row.label }}"
+               {% if not loop.first %}hidden{% endif %}>
+            <span class="install__prompt">$</span>
+            <code class="install__cmd">{{ row.cmd }}</code>
+            <button class="install__copy" type="button"
+                    data-copy="{{ row.cmd }}" aria-label="Copy command">copy</button>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
 
-    <div class="cards">
-      {% for card in section.extra.cards %}
-        <a class="card" href="{{ get_url(path=card.href) }}">
-          <div class="card__title">▸ {{ card.title }}</div>
-          <div class="card__blurb">{{ card.blurb }}</div>
+    {% set devlog = get_section(path="devlog/_index.md") %}
+    {% if devlog.pages | length > 0 %}
+      {% set latest = devlog.pages | first %}
+      <section class="splash__devlog">
+        <div class="splash__devlog-header">
+          <span class="splash__devlog-eyebrow">LATEST DEVLOG</span>
+          <a class="splash__devlog-all" href="{{ get_url(path='@/devlog/_index.md') }}">all posts →</a>
+        </div>
+        <a class="splash__devlog-card" href="{{ latest.permalink }}">
+          <div class="splash__devlog-meta">
+            <span class="devlog__date">{{ latest.date | date(format='%Y-%m-%d') }}</span>
+            <span class="devlog__reading">{{ latest.reading_time }} min read</span>
+          </div>
+          <div class="splash__devlog-title">{{ latest.title }}</div>
+          {% set excerpt = latest.summary | default(value=latest.content) | striptags | trim %}
+          {% if excerpt %}
+            <p class="splash__devlog-excerpt">{{ excerpt | truncate(length=220) }}</p>
+          {% endif %}
         </a>
-      {% endfor %}
-    </div>
+      </section>
+    {% endif %}
 
-    {{ section.content | safe }}
   </section>
 </main>
 {% endblock %}

--- a/site/templates/partials/devlog-sidebar.html
+++ b/site/templates/partials/devlog-sidebar.html
@@ -1,0 +1,12 @@
+{% set devlog = get_section(path="devlog/_index.md") %}
+<nav class="sidebar" aria-label="Devlog navigation">
+  <div class="sidebar__title">devlog/</div>
+  <ul>
+    {% for p in devlog.pages %}
+      <li>
+        <a href="{{ p.permalink }}"
+           class="{% if current_path == p.path %}active{% endif %}">{% if current_path == p.path %}●{% else %}○{% endif %} <span class="sidebar__date">{{ p.date | date(format='%Y-%m-%d') }}</span> {{ p.title }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/site/templates/partials/sidebar.html
+++ b/site/templates/partials/sidebar.html
@@ -5,6 +5,7 @@
     {# Subsections first (folders), then pages (top-level files). #}
     {% for sub_path in root.subsections %}
       {% set sub = get_section(path=sub_path) %}
+      {% if sub.path is starting_with("/devlog") %}{% continue %}{% endif %}
       <li>
         <a class="section-label{% if current_path is starting_with(sub.path) %} active{% endif %}"
            href="{{ sub.permalink }}">▸ {{ sub.title }}</a>


### PR DESCRIPTION
The install commands collapse into a single tabbed card with per-manager panes and a shared copy button, replacing the stacked rows. The static tagline paragraph and the docs-shortcut card grid are gone, letting the landing focus on logo, install, and a new devlog card that lists the newest post with date, reading time, excerpt, and an "all posts" link.

The devlog gets its own sidebar that lists posts by date and marks the active one with the same ●/○ treatment used in docs. The docs sidebar filters /devlog out so it only appears under its own section. Finally .splash__gif is reordered after .gif so its margin: auto isn't clobbered and the demo gif actually centers.