### PR TITLE
App-id was deprecated in favor of client-id

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.RENOVATE_APPROVER_APP_ID }}
+          client-id: ${{ vars.RENOVATE_APPROVER_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APPROVER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.RENOVATE_APP_ID }}
+          client-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |


### PR DESCRIPTION
Replaces app-id with client-id for `actions/create-github-app-token`.

Reference: https://github.com/actions/create-github-app-token/pull/353