### PR TITLE
Disable pinDigest updates for renovate custom regex manager

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -77,6 +77,18 @@
       "pinDigests": false
     },
     {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "ghcr.io/renovatebot/renovate"
+      ],
+      "matchUpdateTypes": [
+        "pinDigest"
+      ],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": [
         "minor",
         "patch"


### PR DESCRIPTION
This errored and failed the rust crate pin-dependencies updates also.