### PR TITLE
Enable daily schedule so PRs are only created during that time frame

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          LOG_LEVEL: ${{ github.event.inputs.log_level || 'debug' }}
+          LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
         with:
           renovate-version: 43.170.20
           configurationFile: renovate-config.json

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-global-schema.json",
   "extends": [
     "config:best-practices",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    "schedule:daily"
   ],
   "rebaseWhen": "behind-base-branch",
   "onboarding": false,
@@ -14,9 +15,6 @@
   "semanticCommits": "disabled",
   "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}",
   "lockFileMaintenance": {
-    "schedule": [
-      "at any time"
-    ],
     "enabled": true
   },
   "customManagers": [


### PR DESCRIPTION
Also revert back to default info level logging. Previously I had to enable some debugging options to understand why I there were no updates for rust crates for some time or lockfile maintenance.