### PR TITLE
Statusbar symbol glyphs

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -9,7 +9,7 @@
 > Allows opening an arbitrary directory as a vault by setting the env var,
 > skipping the splash screen and going straight to the explorer.
 
-- [9bb26d8](https://github.com/erikjuhani/basalt/commit/9bb26d8e618ed09b2f3d1ebab5709a08d6b82acf) Add scrollbar to vault selector
+- [9bb26d8](https://github.com/erikjuhani/basalt/commit/9bb26d8e618ed09b2f3d1ebab5709a08d6b82acf) Add scrollbar to vault selector by @erikjuhani
 
 > The scrollbar is now visible in both splash screen and the vault
 > selector modal. It's not optimal, but I realized that vault selection
@@ -120,7 +120,7 @@
 > input modal positions from `Item::depth()`, placing it flush-left for
 > nested files.
 
-- [6da6548](https://github.com/erikjuhani/basalt/commit/6da6548325725d96a712665fe81273526da0c4df) Preserve note scroll position when toggling explorer folders
+- [6da6548](https://github.com/erikjuhani/basalt/commit/6da6548325725d96a712665fe81273526da0c4df) Preserve note scroll position when toggling explorer folders by @erikjuhani
 
 > Toggling a folder open or closed re-emitted SelectNote for the currently
 > selected note, which rebuilt the note editor and reset its viewport
@@ -130,6 +130,11 @@
 > was actually selected, and the explorer only emits SelectNote in that
 > case, which then effectively retains the scroll position of the
 > viewport.
+
+- [79082f3](https://github.com/erikjuhani/basalt/commit/79082f317efc499febb6bc7c892cd7f6c84b2887) Use config symbols for status bar component badge
+
+> Pass the configured symbol preset into StatusBar so the active component
+> badge falls back to ASCII-safe glyphs when the Ascii preset is selected.
 
 ## [0.12.4](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.12.4) (Apr, 09 2026)
 

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -673,7 +673,7 @@ impl<'a> App<'a> {
             char_count.into(),
         );
 
-        let status_bar = StatusBar::default();
+        let status_bar = StatusBar::new(&self.config.symbols);
         status_bar.render(statusbar, buf, &mut status_bar_state);
 
         self.render_modals(area, buf, state);

--- a/basalt/src/config/mod.rs
+++ b/basalt/src/config/mod.rs
@@ -1,6 +1,6 @@
 mod env;
 mod key_binding;
-mod symbol;
+pub mod symbol;
 
 use core::fmt;
 use std::{collections::BTreeMap, fs::read_to_string};

--- a/basalt/src/statusbar.rs
+++ b/basalt/src/statusbar.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Flex, Layout, Rect},
@@ -7,6 +5,8 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{StatefulWidget, Widget},
 };
+
+use crate::config::{symbol::Preset, Symbols};
 
 #[derive(Default, Clone, PartialEq)]
 pub struct StatusBarState<'a> {
@@ -25,9 +25,14 @@ impl<'a> StatusBarState<'a> {
     }
 }
 
-#[derive(Default)]
 pub struct StatusBar<'a> {
-    _lifetime: PhantomData<&'a ()>,
+    symbols: &'a Symbols,
+}
+
+impl<'a> StatusBar<'a> {
+    pub(crate) fn new(symbols: &'a Symbols) -> Self {
+        Self { symbols }
+    }
 }
 
 impl<'a> StatefulWidget for StatusBar<'a> {
@@ -38,15 +43,21 @@ impl<'a> StatefulWidget for StatusBar<'a> {
             .flex(Flex::SpaceBetween)
             .areas(area);
 
+        let (badge_left, badge_right) = if self.symbols.preset != Preset::Ascii {
+            ("", "")
+        } else {
+            ("", "")
+        };
+
         let active_component = [
-            Span::from("").dark_gray(),
+            Span::from(badge_left).dark_gray(),
             Span::from(" ").bg(Color::DarkGray),
             Span::from(state.active_component_name)
                 .dark_gray()
                 .reversed()
                 .bold(),
             Span::from(" ").bg(Color::DarkGray),
-            Span::from("").dark_gray(),
+            Span::from(badge_right).dark_gray(),
         ]
         .to_vec();
 


### PR DESCRIPTION
[Use config symbols for status bar component badge](https://github.com/erikjuhani/basalt/commit/79082f317efc499febb6bc7c892cd7f6c84b2887) 

Pass the configured symbol preset into StatusBar so the active component
badge falls back to ASCII-safe glyphs when the Ascii preset is selected.

Fixes #457 