### PR TITLE
Add basalt CLI layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +120,7 @@ name = "basalt-tui"
 version = "0.12.5"
 dependencies = [
  "basalt-core 0.9.0",
+ "clap",
  "crossterm",
  "etcetera",
  "indoc",
@@ -178,6 +229,52 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -630,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +976,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,9 +1166,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]

--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.12.5](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.12.5) (Unreleased)
+## [0.12.5](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.12.5) (May, 16 2026)
 
 ### Added
 
@@ -16,6 +16,13 @@
 > needs a rewrite, thus I didn't bother to do this properly for example
 > the scrollbar is always shown if we have more than 4 items regardless if
 > we have space to show all items and not needing a scrollbar.
+
+- [8e248e7](https://github.com/erikjuhani/basalt/commit/8e248e736afd27a36ba941479f68c8fa858bda9f) Add basalt CLI layer
+
+> Initial CLI layer with --version and --help flags. The version output is
+> in a "standard" format similar to cargo version output `0.12.5 (abc123def 2026-05-15)`.
+>
+> The values are populated by a build phase (compile time) using env vars.
 
 ### Changed
 
@@ -131,7 +138,7 @@
 > case, which then effectively retains the scroll position of the
 > viewport.
 
-- [79082f3](https://github.com/erikjuhani/basalt/commit/79082f317efc499febb6bc7c892cd7f6c84b2887) Use config symbols for status bar component badge
+- [79082f3](https://github.com/erikjuhani/basalt/commit/79082f317efc499febb6bc7c892cd7f6c84b2887) Use config symbols for status bar component badge by @erikjuhani
 
 > Pass the configured symbol preset into StatusBar so the active component
 > badge falls back to ASCII-safe glyphs when the Ascii preset is selected.

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -13,6 +13,7 @@ default-run = "basalt"
 
 [dependencies]
 basalt-core = { path = "../basalt-core", version = "0.9.0" }
+clap = { version = "4.6.1", features = ["derive", "string"] }
 ratatui = { version = "0.30.0" }
 crossterm = "0.29.0"
 pulldown-cmark = "0.13.0"

--- a/basalt/build.rs
+++ b/basalt/build.rs
@@ -1,0 +1,60 @@
+use std::{env, path::Path, process::Command};
+
+fn main() {
+    let Some(commit_info) = commit_info() else {
+        return;
+    };
+
+    let version = env::var("CARGO_PKG_VERSION").unwrap();
+
+    println!(
+        "cargo:rustc-env=BASALT_COMMIT_SHORT_HASH={}",
+        commit_info.short_hash
+    );
+    println!("cargo:rustc-env=BASALT_COMMIT_HASH={}", commit_info.hash);
+    println!("cargo:rustc-env=BASALT_COMMIT_DATE={}", commit_info.date);
+    println!("cargo:rustc-env=BASALT_VERSION={version}");
+}
+
+struct CommitInfo {
+    hash: String,
+    short_hash: String,
+    date: String,
+}
+
+fn commit_info() -> Option<CommitInfo> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let workspace_root = Path::new(&manifest_dir).parent()?;
+
+    // Not a git directory
+    if !workspace_root.join(".git").exists() {
+        return None;
+    }
+
+    // Reference for commit info output: https://github.com/rust-lang/cargo/blob/a967402/build.rs#L60
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--format=%H %h %cd")
+        .arg("--abbrev=9")
+        .output()
+    {
+        Ok(output) if output.status.success() => Some(output),
+        _ => None,
+    }?;
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = stdout.trim();
+    let mut parts = stdout.split_whitespace().map(|s| s.to_string());
+
+    let hash = parts.next()?;
+    let short_hash = parts.next()?;
+    let date = parts.next()?;
+
+    Some(CommitInfo {
+        hash,
+        short_hash,
+        date,
+    })
+}

--- a/basalt/src/cli.rs
+++ b/basalt/src/cli.rs
@@ -1,0 +1,38 @@
+use clap::Parser;
+
+use crate::version;
+
+const VERSION_INFO: version::VersionInfo = version::VersionInfo::from_env();
+
+#[derive(Parser)]
+#[command(name = "basalt", version = VERSION_INFO.to_string())]
+pub struct Cli {}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use crate::{cli::Cli, version};
+
+    #[test]
+    fn version_output() {
+        let help = Cli::command()
+            .version(
+                version::VersionInfo {
+                    version: "0.12.5",
+                    short_hash: "abc123def",
+                    date: "2026-05-15",
+                }
+                .to_string(),
+            )
+            .render_version()
+            .to_string();
+        insta::assert_snapshot!(help)
+    }
+
+    #[test]
+    fn help_output() {
+        let help = Cli::command().render_help().to_string();
+        insta::assert_snapshot!(help)
+    }
+}

--- a/basalt/src/lib.rs
+++ b/basalt/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod cli;
 pub mod command;
 pub mod config;
 pub mod explorer;
@@ -13,3 +14,4 @@ pub mod text_counts;
 pub mod toast;
 pub mod vault_selector;
 pub mod vault_selector_modal;
+pub mod version;

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -1,9 +1,12 @@
+use clap::Parser;
 use std::path::PathBuf;
 
 use basalt_core::obsidian::{self, Error, Vault};
-use basalt_tui::app::App;
+use basalt_tui::{app::App, cli::Cli};
 
 fn main() -> Result<(), Error> {
+    let _cli = Cli::parse();
+
     let obsidian_config = obsidian::config::load().unwrap();
     let vaults = obsidian_config.vaults();
 

--- a/basalt/src/snapshots/basalt_tui__cli__tests__help_output.snap
+++ b/basalt/src/snapshots/basalt_tui__cli__tests__help_output.snap
@@ -1,0 +1,9 @@
+---
+source: basalt/src/cli.rs
+expression: help
+---
+Usage: basalt
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version

--- a/basalt/src/snapshots/basalt_tui__cli__tests__version_output.snap
+++ b/basalt/src/snapshots/basalt_tui__cli__tests__version_output.snap
@@ -1,0 +1,5 @@
+---
+source: basalt/src/cli.rs
+expression: help
+---
+basalt 0.12.5 (abc123def 2026-05-15)

--- a/basalt/src/version.rs
+++ b/basalt/src/version.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct VersionInfo {
+    pub version: &'static str,
+    pub short_hash: &'static str,
+    pub date: &'static str,
+}
+
+impl VersionInfo {
+    pub const fn from_env() -> Self {
+        Self {
+            version: env!("BASALT_VERSION"),
+            short_hash: env!("BASALT_COMMIT_SHORT_HASH"),
+            date: env!("BASALT_COMMIT_DATE"),
+        }
+    }
+}
+
+impl fmt::Display for VersionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({} {})", self.version, self.short_hash, self.date)
+    }
+}
+
+#[test]
+fn version_format() {
+    let info = VersionInfo {
+        version: "0.12.5",
+        short_hash: "abc123def",
+        date: "2026-05-15",
+    };
+    assert_eq!(info.to_string(), "0.12.5 (abc123def 2026-05-15)");
+}


### PR DESCRIPTION
Wire clap into main as a thin cli layer. The derive gives --version (rendered from build-time VersionInfo) and --help, with proper error handling for unknown flags. The new build file captures the commit hash and date into env vars consumed by version module.

Fixes #127 