### PR TITLE
Fix renovate zizmor version extraction regex

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -49,7 +49,7 @@
         ".github/workflows/workflow-security.yml"
       ],
       "matchStrings": [
-        "name: zizmor\\s+uses: zizmorcore/zizmor-action@[a-f0-9]+ # [^\\s]+\\s+with:[\\s\\S]*?version: (?<currentValue>v[0-9.]+)"
+        "name: zizmor\\s+uses: zizmorcore/zizmor-action@[a-f0-9]+ # [^\\s]+\\s+with:[\\s\\S]*?version: v(?<currentValue>[0-9.]+)"
       ],
       "depNameTemplate": "zizmorcore/zizmor",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
Move version `v` prefix outside of the current value matcher. Otherwise we might get a plain version number without the `v` prefix and this would then be evaluated as invalid version number for the zizmor action.