### PR TITLE
Update zizmor-action to support the latest zizmor 1.25.0 version

### DIFF
--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -40,7 +40,7 @@ jobs:
           skip_push: "true"
 
       - name: zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727 # v0.5.4
         with:
           annotations: true
           advanced-security: false


### PR DESCRIPTION
Otherwise the workflow security would fail with:
`Error: Unknown version: 1.25.0`.