### PR TITLE
Fix create-github-app-token input names

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           client-id: ${{ vars.RENOVATE_APPROVER_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APPROVER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repository: basalt
           permission-pull-requests: write
 
       - name: Check and approve

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -73,15 +73,13 @@ jobs:
         with:
           client-id: ${{ vars.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repository: basalt
           permission-administration: read
-          permission-dependabot-alerts: read
+          permission-vulnerability-alerts: read
           permission-issues: write
           permission-contents: write
           permission-workflows: write
           permission-pull-requests: write
-          permission-commit-statuses: write
+          permission-statuses: write
 
       - name: Restore cache
         if: github.event.inputs.repoCache != 'disabled'


### PR DESCRIPTION
Three inputs didn't match the action's schema, which likely broke token creation:

- permission-dependabot-alerts -> permission-vulnerability-alerts
- permission-commit-statuses -> permission-statuses

Drop owner and repositories so the token defaults to the current repository, which is the intended scope in both workflows.