### PR TITLE
Tolerate missing commit info via option_env!

### DIFF
--- a/basalt/build.rs
+++ b/basalt/build.rs
@@ -1,19 +1,16 @@
 use std::{env, path::Path, process::Command};
 
 fn main() {
-    let Some(commit_info) = commit_info() else {
+    let Some(commit) = commit_info_from_git().or_else(commit_info_from_source_tarball) else {
         return;
     };
 
-    let version = env::var("CARGO_PKG_VERSION").unwrap();
-
+    println!("cargo:rustc-env=BASALT_COMMIT_HASH={}", commit.hash);
     println!(
         "cargo:rustc-env=BASALT_COMMIT_SHORT_HASH={}",
-        commit_info.short_hash
+        commit.short_hash
     );
-    println!("cargo:rustc-env=BASALT_COMMIT_HASH={}", commit_info.hash);
-    println!("cargo:rustc-env=BASALT_COMMIT_DATE={}", commit_info.date);
-    println!("cargo:rustc-env=BASALT_VERSION={version}");
+    println!("cargo:rustc-env=BASALT_COMMIT_DATE={}", commit.date);
 }
 
 struct CommitInfo {
@@ -22,17 +19,17 @@ struct CommitInfo {
     date: String,
 }
 
-fn commit_info() -> Option<CommitInfo> {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+// Reference: https://github.com/rust-lang/cargo/blob/91fbe9/build.rs#L60-L116
+fn commit_info_from_git() -> Option<CommitInfo> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").ok()?;
     let workspace_root = Path::new(&manifest_dir).parent()?;
 
-    // Not a git directory
     if !workspace_root.join(".git").exists() {
         return None;
     }
 
-    // Reference for commit info output: https://github.com/rust-lang/cargo/blob/a967402/build.rs#L60
     let output = match Command::new("git")
+        .current_dir(workspace_root)
         .arg("log")
         .arg("-1")
         .arg("--date=short")
@@ -40,21 +37,47 @@ fn commit_info() -> Option<CommitInfo> {
         .arg("--abbrev=9")
         .output()
     {
-        Ok(output) if output.status.success() => Some(output),
-        _ => None,
-    }?;
+        Ok(output) if output.status.success() => output,
+        _ => return None,
+    };
 
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    let stdout = stdout.trim();
+    let stdout = String::from_utf8(output.stdout).ok()?;
     let mut parts = stdout.split_whitespace().map(|s| s.to_string());
 
-    let hash = parts.next()?;
-    let short_hash = parts.next()?;
-    let date = parts.next()?;
+    Some(CommitInfo {
+        hash: parts.next()?,
+        short_hash: parts.next()?,
+        date: parts.next()?,
+    })
+}
+
+// Source tarballs published to crates.io don't include a `.git` directory, so `git log` can't
+// populate the commit hash and date at build time.
+//
+// To work around this, the release workflow writes a `git-commit-info` file before `cargo publish`
+// packages the crate; cargo bundles the file into the tarball, and this function reads it on
+// consumer builds.
+//
+// The file is a newline-separated list of full commit hash, short commit hash, and commit date.
+// Reference: https://github.com/rust-lang/cargo/blob/91fbe9/build.rs#L60-L116
+fn commit_info_from_source_tarball() -> Option<CommitInfo> {
+    let path = Path::new("git-commit-info");
+    if !path.exists() {
+        return None;
+    }
+
+    // Dependency tracking is a nice to have for this (git doesn't do it), so if the path is not
+    // valid UTF-8 just avoid doing it rather than erroring out.
+    if let Some(utf8) = path.to_str() {
+        println!("cargo:rerun-if-changed={utf8}");
+    }
+
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut parts = content.split('\n').map(|s| s.to_string());
 
     Some(CommitInfo {
-        hash,
-        short_hash,
-        date,
+        hash: parts.next()?,
+        short_hash: parts.next()?,
+        date: parts.next()?,
     })
 }

--- a/basalt/src/cli.rs
+++ b/basalt/src/cli.rs
@@ -20,8 +20,9 @@ mod tests {
             .version(
                 version::VersionInfo {
                     version: "0.12.5",
-                    short_hash: "abc123def",
-                    date: "2026-05-15",
+                    hash: Some("abc123def0123456789"),
+                    short_hash: Some("abc123def"),
+                    date: Some("2026-05-15"),
                 }
                 .to_string(),
             )

--- a/basalt/src/version.rs
+++ b/basalt/src/version.rs
@@ -1,34 +1,56 @@
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Default)]
 pub struct VersionInfo {
     pub version: &'static str,
-    pub short_hash: &'static str,
-    pub date: &'static str,
+    pub hash: Option<&'static str>,
+    pub short_hash: Option<&'static str>,
+    pub date: Option<&'static str>,
 }
 
 impl VersionInfo {
     pub const fn from_env() -> Self {
         Self {
-            version: env!("BASALT_VERSION"),
-            short_hash: env!("BASALT_COMMIT_SHORT_HASH"),
-            date: env!("BASALT_COMMIT_DATE"),
+            version: env!("CARGO_PKG_VERSION"),
+            hash: option_env!("BASALT_COMMIT_HASH"),
+            short_hash: option_env!("BASALT_COMMIT_SHORT_HASH"),
+            date: option_env!("BASALT_COMMIT_DATE"),
         }
     }
 }
 
 impl fmt::Display for VersionInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ({} {})", self.version, self.short_hash, self.date)
+        write!(f, "{}", self.version)?;
+        match (self.short_hash, self.date) {
+            (None, _) => Ok(()),
+            (Some(short_hash), None) => write!(f, " ({})", short_hash),
+            (Some(short_hash), Some(date)) => write!(f, " ({} {})", short_hash, date),
+        }
     }
 }
 
-#[test]
-fn version_format() {
-    let info = VersionInfo {
-        version: "0.12.5",
-        short_hash: "abc123def",
-        date: "2026-05-15",
-    };
-    assert_eq!(info.to_string(), "0.12.5 (abc123def 2026-05-15)");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_commit_info() {
+        let info = VersionInfo {
+            version: "0.12.5",
+            hash: Some("abc123def0123456789"),
+            short_hash: Some("abc123def"),
+            date: Some("2026-05-15"),
+        };
+        assert_eq!(info.to_string(), "0.12.5 (abc123def 2026-05-15)");
+    }
+
+    #[test]
+    fn without_commit_info() {
+        let info = VersionInfo {
+            version: "0.12.5",
+            ..Default::default()
+        };
+        assert_eq!(info.to_string(), "0.12.5");
+    }
 }


### PR DESCRIPTION
env!() panicked at compile time when BASALT_COMMIT_* vars weren't set, breaking cargo publish and cargo install. Switch to option_env! with Option fields on VersionInfo, omit the parens in Display when absent. Add commit_info_from_source_tarball() to read a git-commit-info file bundled into the published tarball.

Reference: https://github.com/rust-lang/cargo/blob/91fbe9/src/cargo/version.rs