### PR TITLE
Watch vault filesystem for changes in Explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -126,6 +126,7 @@ dependencies = [
  "indoc",
  "insta",
  "natord",
+ "notify-debouncer-full",
  "pulldown-cmark",
  "ratatui",
  "serde",
@@ -298,7 +299,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +466,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -502,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -512,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -539,6 +540,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -580,6 +590,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "generic-array"
@@ -702,6 +721,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +805,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -892,7 +951,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -922,6 +981,46 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1347,7 +1446,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1586,7 +1685,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2062,7 +2161,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2079,12 +2178,86 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -24,6 +24,7 @@ etcetera = "0.11.0"
 thiserror = "2.0.16"
 unicode-width = "0.2.0"
 natord = "1.0.9"
+notify-debouncer-full = "0.7.0"
 
 [dev-dependencies]
 indoc = "=2.0.7"

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -12,7 +12,7 @@ use std::{
     fmt::Debug,
     fs,
     io::Result,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
@@ -34,6 +34,7 @@ use crate::{
     text_counts::{CharCount, WordCount},
     toast::{self, Toast, TOAST_WIDTH},
     vault_selector_modal::{self, VaultSelectorModal, VaultSelectorModalState},
+    vault_watcher::VaultWatcher,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -114,6 +115,7 @@ pub enum Message<'a> {
         rename: Option<(PathBuf, PathBuf)>,
         select: Option<PathBuf>,
     },
+    RescanVault,
     CreateUntitledNote,
     CreateUntitledFolder,
     OpenVault(&'a Vault),
@@ -207,6 +209,7 @@ pub struct App<'a> {
     state: AppState<'a>,
     config: Config<'a>,
     terminal: RefCell<DefaultTerminal>,
+    vault_watcher: RefCell<Option<VaultWatcher>>,
 }
 
 impl<'a> App<'a> {
@@ -216,7 +219,31 @@ impl<'a> App<'a> {
             // TODO: Surface toast if read config returns error
             config,
             terminal: RefCell::new(terminal),
+            vault_watcher: RefCell::new(None),
         }
+    }
+
+    fn ensure_watcher_for(&self, path: &Path) {
+        let mut current = self.vault_watcher.borrow_mut();
+        let needs_swap = match current.as_ref() {
+            Some(watcher) => watcher.path() != path,
+            None => !path.as_os_str().is_empty(),
+        };
+        if !needs_swap {
+            return;
+        }
+        *current = if path.is_dir() {
+            VaultWatcher::new(path).ok()
+        } else {
+            None
+        };
+    }
+
+    fn watcher_has_changes(&self) -> bool {
+        self.vault_watcher
+            .borrow()
+            .as_ref()
+            .is_some_and(|w| w.drain())
     }
 
     pub fn start(
@@ -267,6 +294,8 @@ impl<'a> App<'a> {
         let mut state = self.state.clone();
         let config = self.config.clone();
 
+        self.ensure_watcher_for(&state.vault.path);
+
         let tick_rate = Duration::from_millis(250);
         let mut last_tick = Instant::now();
 
@@ -282,7 +311,16 @@ impl<'a> App<'a> {
                 while message.is_some() {
                     message = App::update(self.terminal.get_mut(), &config, &mut state, message);
                 }
+                self.ensure_watcher_for(&state.vault.path);
             }
+
+            if self.watcher_has_changes() {
+                let mut message = Some(Message::RescanVault);
+                while message.is_some() {
+                    message = App::update(self.terminal.get_mut(), &config, &mut state, message);
+                }
+            }
+
             if last_tick.elapsed() >= tick_rate {
                 App::update(
                     self.terminal.get_mut(),
@@ -432,6 +470,10 @@ impl<'a> App<'a> {
                     ]));
                 }
                 return Some(Message::SetActivePane(ActivePane::Explorer));
+            }
+            Message::RescanVault => {
+                let select = state.selected_note.as_ref().map(|note| note.path.clone());
+                state.explorer.with_entries(state.vault.entries(), select);
             }
             Message::CreateUntitledNote => {
                 let path = match state.explorer.current_item() {

--- a/basalt/src/lib.rs
+++ b/basalt/src/lib.rs
@@ -14,4 +14,5 @@ pub mod text_counts;
 pub mod toast;
 pub mod vault_selector;
 pub mod vault_selector_modal;
+pub mod vault_watcher;
 pub mod version;

--- a/basalt/src/vault_watcher.rs
+++ b/basalt/src/vault_watcher.rs
@@ -1,0 +1,107 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc::{self, Receiver},
+    time::Duration,
+};
+
+use notify_debouncer_full::{
+    new_debouncer,
+    notify::{RecommendedWatcher, RecursiveMode},
+    DebounceEventResult, Debouncer, RecommendedCache,
+};
+
+const DEBOUNCE: Duration = Duration::from_millis(250);
+
+pub struct VaultWatcher {
+    _debouncer: Debouncer<RecommendedWatcher, RecommendedCache>,
+    rx: Receiver<()>,
+    path: PathBuf,
+}
+
+impl VaultWatcher {
+    pub fn new(path: &Path) -> notify_debouncer_full::notify::Result<Self> {
+        let (tx, rx) = mpsc::channel::<()>();
+
+        let mut debouncer = new_debouncer(DEBOUNCE, None, move |result: DebounceEventResult| {
+            let Ok(events) = result else { return };
+            let relevant = events
+                .iter()
+                .flat_map(|event| event.paths.iter())
+                .any(|p| is_relevant_path(p));
+            if relevant {
+                let _ = tx.send(());
+            }
+        })?;
+
+        debouncer.watch(path, RecursiveMode::Recursive)?;
+
+        Ok(VaultWatcher {
+            _debouncer: debouncer,
+            rx,
+            path: path.to_path_buf(),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Drains all pending events and returns true if at least one was received.
+    pub fn drain(&self) -> bool {
+        let mut received = false;
+        while self.rx.try_recv().is_ok() {
+            received = true;
+        }
+        received
+    }
+}
+
+fn is_relevant_path(path: &Path) -> bool {
+    // Skip anything inside a hidden directory (`.obsidian`, `.git`, …) and
+    // hidden files / editor swap files at the vault root.
+    if path
+        .components()
+        .any(|c| matches!(c.as_os_str().to_str(), Some(s) if s.starts_with('.')))
+    {
+        return false;
+    }
+
+    // Accept Markdown files and paths with no extension (directories or
+    // unknown — the explorer rescan will sort them out).
+    match path.extension() {
+        Some(ext) => ext == "md",
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_relevant_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn markdown_files_are_relevant() {
+        assert!(is_relevant_path(&PathBuf::from("/vault/note.md")));
+        assert!(is_relevant_path(&PathBuf::from("/vault/sub/note.md")));
+    }
+
+    #[test]
+    fn directories_are_relevant() {
+        assert!(is_relevant_path(&PathBuf::from("/vault/new-folder")));
+    }
+
+    #[test]
+    fn hidden_paths_are_ignored() {
+        assert!(!is_relevant_path(&PathBuf::from(
+            "/vault/.obsidian/workspace.json"
+        )));
+        assert!(!is_relevant_path(&PathBuf::from("/vault/.git/HEAD")));
+        assert!(!is_relevant_path(&PathBuf::from("/vault/.DS_Store")));
+    }
+
+    #[test]
+    fn non_markdown_files_are_ignored() {
+        assert!(!is_relevant_path(&PathBuf::from("/vault/image.png")));
+        assert!(!is_relevant_path(&PathBuf::from("/vault/note.md.swp")));
+    }
+}


### PR DESCRIPTION
Closes #525

The Explorer file list was loaded once at startup and only refreshed when the user renamed a note or created a new one. External changes (file moves, additions, deletions made outside basalt) weren't reflected until the next user-initiated refresh, and renaming a moved note acted on the stale path.

This PR adds a `notify-debouncer-full` watcher that observes the vault root recursively and dispatches `RefreshVault` when relevant paths change. It filters to markdown files and directories (skips hidden trees like .obsidian and .git). The watcher is rebuilt when the active vault changes.

Also added a focus_explorer field to `RefreshVault` so the watcher-driven case doesn't steal focus from the editor.

I tested this locally on my vault and it seems to work as intended. Let me know what you think. Thank you for this project.