### PR TITLE
Add buffer_offset method to TextBuffer

### DIFF
--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -175,9 +175,7 @@ impl Cursor {
         match message {
             MoveLeft(amount) => {
                 if let Some(text_buffer) = text_buffer {
-                    let byte_idx = self
-                        .source_offset
-                        .saturating_sub(text_buffer.source_range.start);
+                    let byte_idx = text_buffer.buffer_offset(self.source_offset);
 
                     let bytes_amount = text_buffer.content[..byte_idx]
                         .chars()
@@ -193,9 +191,7 @@ impl Cursor {
 
             MoveRight(amount) => {
                 if let Some(text_buffer) = text_buffer {
-                    let byte_idx = self
-                        .source_offset
-                        .saturating_sub(text_buffer.source_range.start);
+                    let byte_idx = text_buffer.buffer_offset(self.source_offset);
 
                     let bytes_amount = text_buffer.content[byte_idx..]
                         .chars()
@@ -320,8 +316,7 @@ impl Cursor {
                 if let Some(text_buffer) = text_buffer {
                     let offset = snap_to_char_boundary(
                         &text_buffer.content,
-                        self.source_offset
-                            .saturating_sub(text_buffer.source_range.start),
+                        text_buffer.buffer_offset(self.source_offset),
                     );
 
                     let mut chars = text_buffer.content[offset..].char_indices();
@@ -346,8 +341,7 @@ impl Cursor {
                 if let Some(text_buffer) = text_buffer {
                     let offset = snap_to_char_boundary(
                         &text_buffer.content,
-                        self.source_offset
-                            .saturating_sub(text_buffer.source_range.start),
+                        text_buffer.buffer_offset(self.source_offset),
                     );
 
                     let mut chars = text_buffer.content[..offset].char_indices().rev();

--- a/basalt/src/note_editor/text_buffer.rs
+++ b/basalt/src/note_editor/text_buffer.rs
@@ -20,8 +20,15 @@ impl TextBuffer {
         }
     }
 
+    /// Converts an absolute source offset into a buffer-relative offset by
+    /// subtracting the buffer's `source_range.start`. Saturates to 0 when the
+    /// offset falls before the start of the buffer's range.
+    pub fn buffer_offset(&self, source_offset: usize) -> usize {
+        source_offset.saturating_sub(self.source_range.start)
+    }
+
     pub fn insert_char(&mut self, c: char, idx: usize) {
-        let byte_idx = idx.saturating_sub(self.source_range.start);
+        let byte_idx = self.buffer_offset(idx);
         let byte_idx = self.content.floor_char_boundary(byte_idx);
 
         self.content.insert(byte_idx, c);
@@ -30,7 +37,7 @@ impl TextBuffer {
     }
 
     pub fn delete_char(&mut self, idx: usize) -> Option<usize> {
-        let byte_idx = idx.saturating_sub(self.source_range.start);
+        let byte_idx = self.buffer_offset(idx);
 
         if let Some((byte_idx, _)) = self.content[..byte_idx].char_indices().next_back() {
             let c = self.content.remove(byte_idx);
@@ -63,6 +70,21 @@ impl TextBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_buffer_offset() {
+        // Zero-start range: source offset maps to itself.
+        let buffer = TextBuffer::new("Hello world", 0..11);
+        assert_eq!(buffer.buffer_offset(6), 6);
+
+        // Offset-start range: source offset is shifted by `start`.
+        let buffer = TextBuffer::new("Hello", 10..15);
+        assert_eq!(buffer.buffer_offset(13), 3);
+        assert_eq!(buffer.buffer_offset(10), 0); // at start
+
+        // Saturates to 0 when the source offset is below `start`.
+        assert_eq!(buffer.buffer_offset(5), 0);
+    }
 
     #[test]
     fn test_insert_ascii_character() {

--- a/basalt/src/note_editor/text_buffer.rs
+++ b/basalt/src/note_editor/text_buffer.rs
@@ -20,9 +20,10 @@ impl TextBuffer {
         }
     }
 
-    /// Converts an absolute source offset into a buffer-relative offset by
-    /// subtracting the buffer's `source_range.start`. Saturates to 0 when the
-    /// offset falls before the start of the buffer's range.
+    /// Converts an absolute source offset into a buffer-relative byte offset
+    /// for indexing into `content`, by subtracting the buffer's
+    /// `source_range.start`. Saturates to 0 when the offset falls before the
+    /// start of the buffer's range.
     pub fn buffer_offset(&self, source_offset: usize) -> usize {
         source_offset.saturating_sub(self.source_range.start)
     }


### PR DESCRIPTION
Closes #324.

Adds `TextBuffer::buffer_offset`, abstracting the repeated `source_offset.saturating_sub(source_range.start)` arithmetic (converting an absolute source offset to a buffer-relative one), and routes the existing call sites through it.

Note: the issue title says `relative_offset` but the code block in the body says `buffer_offset`. Went with `buffer_offset` to match the proposed code; happy to rename to `relative_offset` if you'd prefer.

**Call sites replaced (6):**
- `cursor.rs` cursor movement: `MoveLeft`, `MoveRight`, `MoveWordForward`, `MoveWordBackward`
- `text_buffer.rs` internal: `insert_char`, `delete_char`

**Left alone deliberately** (look similar, aren't the same operation): the `VirtualLine` span offset in `source_offset_to_virtual_column` (subtracts a span's start, not a `TextBuffer`'s), and the `.end`-relative `saturating_sub` calls.

Behavior-preserving: each replacement expands to the exact expression it replaced. Added a `test_buffer_offset` unit test (zero-start, offset-start, saturate-below-start). `cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` all clean.

One observation, not addressed here: `buffer_offset` returns the raw difference, so for an out-of-range input the result can exceed `content.len()`. That matches the pre-existing behavior at every call site, so I kept it a straight extraction. Flagging it since making the method `pub` makes it reachable for new callers, in case you'd want a clamp or a doc note in a follow-up.
