### PR TITLE
Pan viewport horizontally to follow the cursor in edit mode

### DIFF
--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -414,7 +414,6 @@ impl StatefulWidget for CursorWidget {
     where
         Self: Sized,
     {
-        let x = area.x.saturating_add(self.offset.x as u16);
         let y = (state.virtual_row as u16)
             .saturating_add(self.meta_len)
             .saturating_sub(area.top())
@@ -423,13 +422,16 @@ impl StatefulWidget for CursorWidget {
         match state.mode {
             CursorMode::Read => {
                 buf.set_style(
-                    Rect::new(x, y, area.width, 1),
+                    Rect::new(self.offset.x as u16, y, area.width, 1),
                     Style::default().reversed().dark_gray(),
                 );
             }
             CursorMode::Edit => {
+                let x = (state.virtual_column as u16)
+                    .saturating_add(self.offset.x as u16)
+                    .saturating_sub(area.left());
                 buf.set_style(
-                    Rect::new(x.saturating_add(state.virtual_column as u16), y, 1, 1),
+                    Rect::new(x, y, 1, 1),
                     Style::default().reversed().dark_gray(),
                 );
             }
@@ -459,6 +461,7 @@ mod tests {
                     content.to_string(),
                     &node,
                     80,
+                    0,
                     Span::default(),
                     &RenderStyle::Raw,
                     &Symbols::unicode(),
@@ -703,6 +706,7 @@ mod tests {
                     content.to_string(),
                     &node,
                     80,
+                    0,
                     Span::default(),
                     &RenderStyle::Reader,
                     &Symbols::unicode(),

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -80,7 +80,10 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
         let rendered_lines_count = state.virtual_document.lines().len();
         let meta_lines_count = state.virtual_document.meta().len();
 
-        Paragraph::new(visible_lines).block(block).render(area, buf);
+        Paragraph::new(visible_lines)
+            .scroll((0, state.viewport().left()))
+            .block(block)
+            .render(area, buf);
 
         if !state.content.is_empty() || state.is_editing() {
             CursorWidget::default()

--- a/basalt/src/note_editor/render.rs
+++ b/basalt/src/note_editor/render.rs
@@ -3,7 +3,7 @@ use ratatui::{
     text::Span,
 };
 
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{
     config::Symbols,
@@ -127,6 +127,14 @@ fn render_raw_line<'a>(
     )
 }
 
+/// Display width of source text, counting tabs as two columns to match how they
+/// are expanded at draw time and how the cursor measures columns.
+fn display_width(text: &str) -> usize {
+    text.chars()
+        .map(|c| if c == '\t' { 2 } else { c.width().unwrap_or(0) })
+        .sum()
+}
+
 /// Renders source lines for edit mode, keeping a 1:1 mapping between source and
 /// display lines. The line under the cursor is shown raw (so its markers and
 /// indentation are editable); every other line is decorated in place — the
@@ -139,8 +147,13 @@ pub fn edit_lines<'a>(
     base: usize,
     cursor_offset: usize,
     max_width: usize,
+    horizontal_offset: usize,
     symbols: &Symbols,
 ) -> Vec<VirtualLine<'a>> {
+    // Full-width fills (code backgrounds, heading rules) extend by the horizontal
+    // scroll so they still span the viewport once it pans to follow the cursor.
+    let fill_width = max_width + horizontal_offset;
+
     let mut lines = Vec::new();
     let mut start = base;
     // Lines inside a fenced code block are literal — never decorated as markdown.
@@ -153,7 +166,7 @@ pub fn edit_lines<'a>(
         let fence = is_code_fence(text);
 
         if in_code || fence {
-            lines.push(code_line(text, &line_range, max_width));
+            lines.push(code_line(text, &line_range, fill_width));
             // A fence toggles the block: the opener enters it, the next closes it.
             in_code ^= fence;
         } else {
@@ -162,6 +175,7 @@ pub fn edit_lines<'a>(
                 &line_range,
                 line_range.contains(&cursor_offset),
                 max_width,
+                fill_width,
                 symbols,
             ));
         }
@@ -175,6 +189,7 @@ fn edit_line<'a>(
     line_range: &SourceRange<usize>,
     is_cursor: bool,
     max_width: usize,
+    fill_width: usize,
     symbols: &Symbols,
 ) -> Vec<VirtualLine<'a>> {
     if text.is_empty() {
@@ -190,7 +205,7 @@ fn edit_line<'a>(
     // Headings always keep their rendered style (bold, colour, underline) while
     // editing; the `#` markers stay visible but dimmed so they can still be edited.
     if let Some(level) = heading_level(rest) {
-        return heading_lines(text, line_range, indent_len, level, max_width, symbols);
+        return heading_lines(text, line_range, indent_len, level, fill_width, symbols);
     }
 
     if is_cursor {
@@ -212,9 +227,13 @@ fn is_code_fence(text: &str) -> bool {
 
 /// Renders a code-block line literally, with the code background, so its content
 /// is never interpreted as markdown.
-fn code_line<'a>(text: &str, line_range: &SourceRange<usize>, max_width: usize) -> VirtualLine<'a> {
+fn code_line<'a>(
+    text: &str,
+    line_range: &SourceRange<usize>,
+    fill_width: usize,
+) -> VirtualLine<'a> {
     let code_bg = Style::new().bg(CODE_BG);
-    let pad = max_width.saturating_sub(text.chars().count() + 1);
+    let pad = fill_width.saturating_sub(display_width(text) + 1);
     virtual_line!([
         synthetic_span!(Span::styled(" ", code_bg)),
         content_span!(Span::raw(text.to_string()).bg(CODE_BG), line_range.clone()),
@@ -230,7 +249,7 @@ fn heading_lines<'a>(
     line_range: &SourceRange<usize>,
     indent_len: usize,
     level: usize,
-    max_width: usize,
+    fill_width: usize,
     symbols: &Symbols,
 ) -> Vec<VirtualLine<'a>> {
     let marker_end = (indent_len + level + 1).min(text.len());
@@ -251,11 +270,11 @@ fn heading_lines<'a>(
 
     match level {
         1 => lines.push(virtual_line!([synthetic_span!(Span::raw(
-            symbols.h1_underline.repeat(max_width)
+            symbols.h1_underline.repeat(fill_width)
         ))])),
         2 => lines.push(virtual_line!([synthetic_span!(symbols
             .h2_underline
-            .repeat(max_width)
+            .repeat(fill_width)
             .yellow())])),
         _ => {}
     }
@@ -455,6 +474,7 @@ pub fn heading<'a>(
     text: &RichText,
     source_range: &SourceRange<usize>,
     max_width: usize,
+    horizontal_offset: usize,
     option: &RenderStyle,
     symbols: &Symbols,
 ) -> VirtualBlock<'a> {
@@ -511,6 +531,8 @@ pub fn heading<'a>(
         wrapped_heading
     };
 
+    // Extend the underline by the horizontal scroll so it still spans the viewport when panned.
+    let underline_width = (max_width + horizontal_offset).saturating_sub(prefix_width);
     let mut lines = match level {
         H1 => h_with_underline(
             if option.is_styled() {
@@ -518,17 +540,11 @@ pub fn heading<'a>(
             } else {
                 text.bold()
             },
-            symbols
-                .h1_underline
-                .repeat(max_width.saturating_sub(prefix_width))
-                .into(),
+            symbols.h1_underline.repeat(underline_width).into(),
         ),
         H2 => h_with_underline(
             text.bold().yellow(),
-            symbols
-                .h2_underline
-                .repeat(max_width.saturating_sub(prefix_width))
-                .yellow(),
+            symbols.h2_underline.repeat(underline_width).yellow(),
         ),
         H3 => h(format!("{} ", symbols.h3_marker).cyan(), text.bold().cyan()),
         H4 => h(
@@ -654,6 +670,8 @@ pub fn paragraph<'a>(
     VirtualBlock::new(&lines, source_range)
 }
 
+// FIXME: Use options struct or similar
+#[allow(clippy::too_many_arguments)]
 pub fn code_block<'a>(
     content: &str,
     prefix: Span<'static>,
@@ -663,8 +681,11 @@ pub fn code_block<'a>(
     text: &RichText,
     source_range: &SourceRange<usize>,
     max_width: usize,
+    horizontal_offset: usize,
     option: &RenderStyle,
 ) -> VirtualBlock<'a> {
+    // Extend the background by the horizontal scroll so it still spans the viewport when panned.
+    let fill_width = max_width + horizontal_offset;
     let lines = match option {
         RenderStyle::Raw => {
             let content = content.get(source_range.clone()).unwrap_or(content);
@@ -682,7 +703,7 @@ pub fn code_block<'a>(
                         content_span!(line.to_string().bg(CODE_BG), line_range),
                         synthetic_span!(" "
                             .repeat(
-                                max_width
+                                fill_width
                                     .saturating_sub(prefix.width() + line.chars().count())
                                     .saturating_sub(1)
                             )
@@ -700,7 +721,7 @@ pub fn code_block<'a>(
             let padding_line = virtual_line!([
                 synthetic_span!(prefix.clone()),
                 synthetic_span!(" "
-                    .repeat(max_width.saturating_sub(prefix.width()))
+                    .repeat(fill_width.saturating_sub(prefix.width()))
                     .bg(CODE_BG))
             ]);
 
@@ -717,7 +738,7 @@ pub fn code_block<'a>(
                     content_span!(line.to_string().bg(CODE_BG), source_range),
                     synthetic_span!(" "
                         .repeat(
-                            max_width
+                            fill_width
                                 .saturating_sub(prefix.width() + line.chars().count())
                                 .saturating_sub(1)
                         )
@@ -741,6 +762,7 @@ pub fn list<'a>(
     nodes: &[ast::Node],
     source_range: &SourceRange<usize>,
     max_width: usize,
+    horizontal_offset: usize,
     option: &RenderStyle,
     symbols: &Symbols,
     list_depth: usize,
@@ -770,6 +792,7 @@ pub fn list<'a>(
                             content.to_string(),
                             node,
                             max_width,
+                            horizontal_offset,
                             prefix.clone(),
                             option,
                             symbols,
@@ -809,6 +832,7 @@ pub fn task<'a>(
     nodes: &[ast::Node],
     source_range: &SourceRange<usize>,
     max_width: usize,
+    horizontal_offset: usize,
     option: &RenderStyle,
     symbols: &Symbols,
     list_depth: usize,
@@ -854,6 +878,7 @@ pub fn task<'a>(
                     content.to_string(),
                     node,
                     max_width,
+                    horizontal_offset,
                     prefix.merge("  ".into()),
                     option,
                     symbols,
@@ -878,6 +903,7 @@ pub fn item<'a>(
     nodes: &[ast::Node],
     source_range: &SourceRange<usize>,
     max_width: usize,
+    horizontal_offset: usize,
     option: &RenderStyle,
     symbols: &Symbols,
     list_depth: usize,
@@ -922,6 +948,7 @@ pub fn item<'a>(
                     content.to_string(),
                     node,
                     max_width,
+                    horizontal_offset,
                     prefix.merge("  ".into()),
                     option,
                     symbols,
@@ -957,6 +984,7 @@ pub fn block_quote<'a>(
     nodes: &[ast::Node],
     source_range: &SourceRange<usize>,
     max_width: usize,
+    horizontal_offset: usize,
     option: &RenderStyle,
     symbols: &Symbols,
 ) -> VirtualBlock<'a> {
@@ -970,6 +998,7 @@ pub fn block_quote<'a>(
                     content.to_string(),
                     node,
                     max_width,
+                    horizontal_offset,
                     prefix.merge(Span::raw("┃ ").magenta()),
                     option,
                     symbols,
@@ -996,6 +1025,7 @@ pub fn render_node<'a>(
     content: String,
     node: &ast::Node,
     max_width: usize,
+    horizontal_offset: usize,
     prefix: Span<'static>,
     option: &RenderStyle,
     symbols: &Symbols,
@@ -1014,6 +1044,7 @@ pub fn render_node<'a>(
             text,
             source_range,
             max_width,
+            horizontal_offset,
             option,
             symbols,
         ),
@@ -1037,6 +1068,7 @@ pub fn render_node<'a>(
             text,
             source_range,
             max_width,
+            horizontal_offset,
             option,
         ),
         List {
@@ -1048,6 +1080,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
             max_width,
+            horizontal_offset,
             option,
             symbols,
             list_depth,
@@ -1063,6 +1096,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
             max_width,
+            horizontal_offset,
             option,
             symbols,
             list_depth,
@@ -1078,6 +1112,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
             max_width,
+            horizontal_offset,
             option,
             symbols,
             list_depth,
@@ -1093,6 +1128,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
             max_width,
+            horizontal_offset,
             option,
             symbols,
         ),

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -295,6 +295,9 @@ impl<'a> NoteEditorState<'a> {
                     self.virtual_document.lines(),
                     &None,
                 );
+                // Read mode never pans horizontally; reset so its width-sized
+                // fills (code backgrounds, rules) line up with the viewport.
+                self.ensure_cursor_visible();
             }
             View::Edit(..) => {
                 self.enter_insert(block_idx);
@@ -322,6 +325,7 @@ impl<'a> NoteEditorState<'a> {
                 self.cursor.source_offset(),
                 &self.ast_nodes,
                 size.width.into(),
+                self.viewport.left().into(),
                 self.text_buffer.clone(),
             );
 
@@ -342,16 +346,27 @@ impl<'a> NoteEditorState<'a> {
     /// to move outside the visible area (e.g., resize, cursor movement).
     fn ensure_cursor_visible(&mut self) {
         let meta_len = self.virtual_document.meta().len() as i32;
-        let cursor_screen_row = self.cursor.virtual_row() as i32 + meta_len;
-        let viewport_top = self.viewport.top() as i32;
-        let viewport_bottom = self.viewport.bottom() as i32;
+        let cursor_row = self.cursor.virtual_row() as i32 + meta_len;
+        let cursor_column = self.cursor.virtual_column() as i32;
 
-        if cursor_screen_row < viewport_top {
-            let scroll_offset = cursor_screen_row - viewport_top;
-            self.viewport.scroll_by((scroll_offset, 0));
-        } else if cursor_screen_row >= viewport_bottom {
-            let scroll_offset = cursor_screen_row - viewport_bottom + 1;
-            self.viewport.scroll_by((scroll_offset, 0));
+        let vertical = if cursor_row < self.viewport.top() as i32 {
+            cursor_row - self.viewport.top() as i32
+        } else if cursor_row >= self.viewport.bottom() as i32 {
+            cursor_row - self.viewport.bottom() as i32 + 1
+        } else {
+            0
+        };
+
+        let horizontal = if cursor_column < self.viewport.left() as i32 {
+            cursor_column - self.viewport.left() as i32
+        } else if cursor_column >= self.viewport.right() as i32 {
+            cursor_column - self.viewport.right() as i32 + 1
+        } else {
+            0
+        };
+
+        if (vertical, horizontal) != (0, 0) {
+            self.viewport.scroll_by((vertical, horizontal));
         }
     }
 
@@ -486,6 +501,7 @@ impl<'a> NoteEditorState<'a> {
             self.cursor.source_offset(),
             &self.ast_nodes,
             self.viewport.area().width.into(),
+            self.viewport.left().into(),
             self.text_buffer.clone(),
         );
 
@@ -571,6 +587,7 @@ impl<'a> NoteEditorState<'a> {
             target_offset.unwrap_or_else(|| self.cursor.source_offset()),
             &self.ast_nodes,
             self.viewport.area().width.into(),
+            self.viewport.left().into(),
             self.text_buffer.clone(),
         );
 
@@ -641,6 +658,14 @@ mod tests {
         assert!(
             cursor_screen_row >= top && cursor_screen_row < bottom,
             "{context}: cursor screen row {cursor_screen_row} outside viewport [{top}, {bottom})",
+        );
+
+        let cursor_column = state.cursor.virtual_column() as i32;
+        let left = state.viewport().left() as i32;
+        let right = state.viewport().right() as i32;
+        assert!(
+            cursor_column >= left && cursor_column < right,
+            "{context}: cursor column {cursor_column} outside viewport [{left}, {right})",
         );
     }
 
@@ -1068,5 +1093,109 @@ mod tests {
 
         state.cursor_up(5);
         assert_cursor_visible(&state, "after cursor_up");
+    }
+
+    #[test]
+    fn test_viewport_scrolls_horizontally_on_long_code_line() {
+        // Code-block lines are not wrapped, so a long one overflows the viewport
+        // and the cursor must pan it horizontally to stay visible.
+        let long = "x".repeat(100);
+        let content = format!("```\n{long}\n```\n");
+
+        let mut state =
+            NoteEditorState::new(&content, "test", Path::new("test.md"), &Symbols::unicode());
+        state.resize_viewport(Size::new(20, 10));
+        state.set_view(View::Edit(EditMode::Source));
+
+        // Land on the code line and walk to its end.
+        state.cursor_down(1);
+        assert_eq!(state.viewport().left(), 0, "no scroll at line start");
+
+        state.cursor_right(80);
+        let panned = state.viewport().left();
+        assert!(panned > 0, "viewport should pan right to follow the cursor");
+        assert_cursor_visible(&state, "after cursor_right on long line");
+
+        state.cursor_left(80);
+        assert!(
+            state.viewport().left() < panned,
+            "viewport should pan back toward the start",
+        );
+        assert_cursor_visible(&state, "after cursor_left on long line");
+    }
+
+    fn widest_line_in_range(state: &NoteEditorState, range: std::ops::Range<usize>) -> usize {
+        state
+            .virtual_document
+            .lines()
+            .iter()
+            .filter(|line| {
+                line.source_range()
+                    .is_some_and(|r| range.contains(&r.start))
+            })
+            .map(|line| line.virtual_spans().iter().map(|span| span.width()).sum())
+            .max()
+            .expect("a line in the given source range")
+    }
+
+    #[test]
+    fn test_code_background_extends_past_horizontal_scroll() {
+        // The active code block has a short line and a long one. Panning right to
+        // follow the long line must keep the short line's background reaching the
+        // viewport's right edge (left + width), not stop at its own content.
+        let content = format!("```\nshort\n{}\n```\n", "x".repeat(100));
+
+        let mut state =
+            NoteEditorState::new(&content, "", Path::new("test.md"), &Symbols::unicode());
+        let width = 20;
+        state.resize_viewport(Size::new(width, 10));
+        state.set_view(View::Edit(EditMode::Source));
+
+        // Step onto the long line and pan into it.
+        state.cursor_down(2);
+        state.cursor_right(80);
+        state.update_layout(); // editor.rs re-lays out against the scroll each frame.
+
+        let left = state.viewport().left() as usize;
+        assert!(left > 0, "expected a horizontal scroll");
+
+        let short_line_width = widest_line_in_range(&state, 4..10);
+        assert!(
+            short_line_width >= left + width as usize,
+            "code background ({short_line_width}) must cover the viewport \
+             ({left} + {width})",
+        );
+    }
+
+    #[test]
+    fn test_non_active_block_fills_extend_past_horizontal_scroll() {
+        // Editing a long line in one block pans the whole viewport. The fills of
+        // the *other* visible blocks must extend too, even though those blocks
+        // are not the one being edited. Here a second, non-active code block.
+        let long = "x".repeat(100);
+        let content = format!("```\n{long}\n```\n\n```\nbbb\n```\n");
+        // The second code block opens at the fence after the blank line.
+        let second_block_start = content.find("\n\n").unwrap() + 2;
+
+        let mut state =
+            NoteEditorState::new(&content, "", Path::new("test.md"), &Symbols::unicode());
+        let width = 20;
+        state.resize_viewport(Size::new(width, 10));
+        state.set_view(View::Edit(EditMode::Source));
+
+        // Pan into the long line of the first (active) code block.
+        state.cursor_down(1);
+        state.cursor_right(80);
+        state.update_layout();
+
+        let left = state.viewport().left() as usize;
+        assert!(left > 0, "expected a horizontal scroll");
+
+        let non_active_width = widest_line_in_range(&state, second_block_start..content.len());
+        assert!(
+            non_active_width >= left + width as usize,
+            "non-active code background ({non_active_width}) must cover the \
+             viewport ({left} + {width})",
+        );
     }
 }

--- a/basalt/src/note_editor/virtual_document.rs
+++ b/basalt/src/note_editor/virtual_document.rs
@@ -234,6 +234,7 @@ impl<'a> VirtualDocument<'a> {
         cursor_offset: usize,
         ast_nodes: &[ast::Node],
         width: usize,
+        horizontal_offset: usize,
         text_buffer: Option<TextBuffer>,
     ) {
         if !note_name.is_empty() {
@@ -251,7 +252,10 @@ impl<'a> VirtualDocument<'a> {
                 &self.symbols,
             );
             meta.extend([
-                virtual_line!([synthetic_span!(self.symbols.horizontal_rule.repeat(width))]),
+                virtual_line!([synthetic_span!(self
+                    .symbols
+                    .horizontal_rule
+                    .repeat(width + horizontal_offset))]),
                 empty_virtual_line!(),
             ]);
 
@@ -298,6 +302,7 @@ impl<'a> VirtualDocument<'a> {
                             range.start,
                             cursor_offset,
                             width,
+                            horizontal_offset,
                             &self.symbols,
                         );
                         VirtualBlock::new(&lines, range)
@@ -306,6 +311,7 @@ impl<'a> VirtualDocument<'a> {
                         live_content.to_string(),
                         node,
                         width,
+                        horizontal_offset,
                         Span::default(),
                         &styled,
                         &self.symbols,


### PR DESCRIPTION
## What

In edit mode, the line under the cursor is shown raw (unwrapped), so a long source line could push the cursor past the right edge of the viewport where it disappeared. The viewport now pans horizontally to keep the cursor visible, mirroring the existing vertical follow logic.

When the document pans, full-width fills have to extend with it or they stop short of the right edge. The horizontal scroll offset is threaded through the render path so code-block backgrounds, heading underlines, and the title rule span `width + offset`, covering every visible block, not just the one being edited.

## Changes

- `ensure_cursor_visible` gains a horizontal axis alongside the vertical one
- `editor.rs` applies the offset to the rendered paragraph; the cursor widget subtracts it when placing the cursor
- Read mode resets the offset, since it never pans
- Render fills (`edit_lines`, `heading`, `code_block`, and the title rule) extend by the offset

## Tests

- Horizontal pan follows the cursor into a long code line and back
- The active block's short lines stay covered when panned
- A non-active code block's background still spans the viewport when another block is panned

All tests, clippy, and fmt pass.