### PR TITLE
Add Cloudflare Web Analytics to the site

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -22,3 +22,5 @@ truncate_content_length = 200
 github_url = "https://github.com/erikjuhani/basalt"
 releases_url = "https://github.com/erikjuhani/basalt/releases"
 basalt_version = "0.12.4"
+
+cloudflare_analytics_token = "b104373a7e7d4fbb9635dc4bd5d1e183"

--- a/site/config.toml
+++ b/site/config.toml
@@ -21,6 +21,5 @@ truncate_content_length = 200
 [extra]
 github_url = "https://github.com/erikjuhani/basalt"
 releases_url = "https://github.com/erikjuhani/basalt/releases"
-basalt_version = "0.12.4"
 
 cloudflare_analytics_token = "b104373a7e7d4fbb9635dc4bd5d1e183"

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -70,5 +70,10 @@
 
   <script>window.SEARCH_INDEX_URL = "{{ get_url(path='search_index.en.js', trailing_slash=false) }}";</script>
   <script src="{{ get_url(path='main.js', trailing_slash=false) }}" defer></script>
+
+  {% if config.extra.cloudflare_analytics_token %}
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "{{ config.extra.cloudflare_analytics_token }}"}'></script>
+  {% endif %}
 </body>
 </html>

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -17,7 +17,7 @@
       <span class="splash__title">
 ⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅
       </span>
-<a style="font-weight: 600" href="{{ get_url(path='@/changelog.md') }}">v{{ config.extra.basalt_version }}</a>
+<a style="font-weight: 600" href="{{ get_url(path='@/changelog.md') }}">v{{ config.extra.basalt_version | default(value="dev") }}</a>
 <br/>
    </span>
     {% if section.extra.demo_gif %}


### PR DESCRIPTION
Adds privacy-friendly per-page analytics to the GitHub Pages site, plus a small cleanup.

## Changes
- **Cloudflare Web Analytics beacon** in `base.html`, gated on `cloudflare_analytics_token` in `site/config.toml` so it only ships when the token is set (local builds stay clean). Covers every page since all templates extend `base.html`.
- **Drop the generated `basalt_version`** from `site/config.toml`. It's already injected from `basalt/Cargo.toml` by `obsidian-to-zola` at build time, so the committed value was dead weight that went stale. The template now falls back to a `dev` default for raw `zola` builds that skip the transform.

## Notes
- The beacon is a client-side script, so ad-blockers that block `cloudflareinsights.com` won't be counted; real traffic reads a bit higher than the dashboard.
- Cloudflare Web Analytics registers by hostname (`erikjuhani.github.io`), but the beacon only loads on Basalt pages, so only `/basalt/...` paths report.