### PR TITLE
Enable Renovate dependency dashboard and drop dead zizmor regex manager

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-global-schema.json",
   "extends": [
     "config:best-practices",
-    ":disableDependencyDashboard",
     "schedule:daily"
   ],
   "rebaseWhen": "behind-base-branch",
@@ -42,17 +41,6 @@
       ],
       "depNameTemplate": "ghcr.io/renovatebot/renovate",
       "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        ".github/workflows/workflow-security.yml"
-      ],
-      "matchStrings": [
-        "name: zizmor\\s+uses: zizmorcore/zizmor-action@[a-f0-9]+ # [^\\s]+\\s+with:[\\s\\S]*?version: v(?<currentValue>[0-9.]+)"
-      ],
-      "depNameTemplate": "zizmorcore/zizmor",
-      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

Two Renovate config cleanups for visibility and to remove dead config:

- **Enable the dependency dashboard** by dropping `:disableDependencyDashboard`. Renovate will open and maintain a "Dependency Dashboard" issue listing pending, blocked and rate-limited updates. The workflow already grants `permission-issues: write`. This surfaces situations like the currently blocked zizmor bump (#552), which otherwise sits silently.
- **Remove the zizmor custom regex manager.** It was redundant with Renovate's native zizmor-action support (the `uses-with` detection that already updates the `version:` input), and its matchString required a `v` prefix the unprefixed `version: 1.25.2` input never has, so it extracted nothing.

The zizmor-action SHA and its `version:` input are still updated by Renovate's built-in `github-actions` manager, so action-version updates are unaffected.

## Checklist

- [x] I ran `make check` (format, clippy, tests, build) — n/a, config-only change (JSON validated)
- [x] I added a `Changelog:` trailer if this should appear in the changelog — n/a, CI/Renovate config
- [ ] I have read and agree to the [Contributor License Agreement](../CLA.md)