### PR TITLE
Explicitly enable Renovate dependency dashboard

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-global-schema.json",
   "extends": [
     "config:best-practices",
+    ":dependencyDashboard",
     "schedule:daily"
   ],
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
## Summary

Follow-up to #557. Removing `:disableDependencyDashboard` only reverted to the Renovate default, which does not create the dashboard issue except under specific triggers (rate-limiting, errors, pending approvals). The post-merge Renovate run confirmed this: no dashboard issue was created and the run log never mentions the dashboard.

Extend `:dependencyDashboard` so the "Dependency Dashboard" issue is always created and maintained. The workflow already grants `permission-issues: write`.

## Checklist

- [x] I ran `make check` (format, clippy, tests, build) — n/a, config-only change (JSON validated)
- [x] I added a `Changelog:` trailer if this should appear in the changelog — n/a, CI/Renovate config
- [ ] I have read and agree to the [Contributor License Agreement](../CLA.md)