### PR TITLE
Update Renovate to 43.234.1

### DIFF
--- a/.github/workflows/renovate-validate.yml
+++ b/.github/workflows/renovate-validate.yml
@@ -31,4 +31,4 @@ jobs:
           persist-credentials: false
 
       - name: Validate Renovate config
-        run: docker run --rm -v "$PWD/renovate-config.json:/tmp/renovate-config.json" ghcr.io/renovatebot/renovate:43.234.0 renovate-config-validator /tmp/renovate-config.json
+        run: docker run --rm -v "$PWD/renovate-config.json:/tmp/renovate-config.json" ghcr.io/renovatebot/renovate:43.234.1 renovate-config-validator /tmp/renovate-config.json

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -109,7 +109,7 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
         with:
-          renovate-version: 43.234.0
+          renovate-version: 43.234.1
           configurationFile: renovate-config.json
           token: '${{ steps.app-token.outputs.token }}'
 


### PR DESCRIPTION
Renovate runs abort with `Repository has changed during renovation - aborting`, which stops any updates from being applied. The run reaches the `renovate/pin-dependencies` branch, hits `Error updating branch: update failure`, then aborts the whole repository before processing the remaining branches.

This is a regression fixed upstream in renovatebot/renovate#44126, released in 43.234.1.

Bumps the pinned Renovate version in both the runner workflow and the config validator:
- `.github/workflows/renovate.yml` (`renovate-version`)
- `.github/workflows/renovate-validate.yml` (validator image tag)