### PR TITLE
Add vim visual selection with clipboard yank

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- [00430a8](https://github.com/erikjuhani/basalt/commit/00430a85d15c49a0b6d5ea81038608ab15abe57d) Add vim visual selection with clipboard yank by @erikjuhani
+
+> Visual selection comes to the vim-mode note editor. `v` starts a
+> charwise selection and `V` a linewise one, motions extend it, `y` yanks
+> the selection to the system clipboard and `esc` cancels. A brief flash
+> marks the yanked range, and the highlight is painted per character and
+> clipped to the editor viewport.
+>
+> Clipboard writes use the platform utility (pbcopy, wl-copy, xclip, xsel
+> or clip) with an OSC 52 fallback for SSH and tmux, so no new dependency
+> is added.
+
 - [1b66afd](https://github.com/erikjuhani/basalt/commit/1b66afdca6c036072981332877fa04b9a6610035) Pan viewport horizontally to follow the cursor in edit mode by @erikjuhani
 
 > Long source lines are shown raw (unwrapped) while editing, so the cursor

--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -70,6 +70,9 @@
 # note_editor_experimental_cursor_word_forward: moves cursor forward by a word
 # note_editor_experimental_cursor_word_backward: moves cursor backwards by a word
 # note_editor_insert_mode: enters insert mode (vim mode)
+# note_editor_visual_mode: starts charwise visual selection (vim mode)
+# note_editor_visual_line_mode: starts linewise visual selection (vim mode)
+# note_editor_yank: copies the visual selection to the clipboard (vim mode)
 #
 # Input modal commands:
 #

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -116,6 +116,7 @@ pub enum Message<'a> {
     Quit,
     Exec(String),
     Spawn(String),
+    CopyToClipboard(String),
     Resize(Size),
     SetActivePane(ActivePane),
     RefreshVault {
@@ -666,6 +667,14 @@ impl<'a> App<'a> {
                     .unwrap_or_default();
 
                 return command::spawn_command(command, &state.vault.name, note_name, &note_path);
+            }
+
+            Message::CopyToClipboard(text) => {
+                let toast = match crate::clipboard::copy(&text) {
+                    Ok(_) => Toast::success("Yanked to clipboard", Duration::from_secs(2)),
+                    Err(_) => Toast::error("Failed to copy to clipboard", Duration::from_secs(2)),
+                };
+                return Some(Message::Toast(toast::Message::Create(toast)));
             }
 
             Message::HelpModal(message) => {

--- a/basalt/src/clipboard.rs
+++ b/basalt/src/clipboard.rs
@@ -1,0 +1,126 @@
+//! Copy text to the host clipboard without a system clipboard dependency.
+//!
+//! Two best-effort paths run together: a native clipboard utility (`pbcopy`,
+//! `wl-copy`, `xclip`, `xsel`, or `clip`) which is reliable locally, and an
+//! OSC 52 terminal escape which travels through SSH and tmux (with
+//! `set-clipboard on`). Terminals that disable OSC 52 ignore it silently, so on
+//! a local session the native utility is what actually fills the clipboard.
+
+use std::{
+    io::{self, Write},
+    process::{Command, Stdio},
+};
+
+/// Copies `text` to the clipboard. Reports success when either the native
+/// utility ran or the OSC 52 escape was written.
+pub fn copy(text: &str) -> io::Result<()> {
+    let native = native_copy(text);
+    let osc52 = osc52(text);
+    if native {
+        Ok(())
+    } else {
+        osc52
+    }
+}
+
+/// Writes `text` to the terminal clipboard using `OSC 52 ; c ; <base64> BEL`.
+fn osc52(text: &str) -> io::Result<()> {
+    let mut stdout = io::stdout();
+    write!(stdout, "\x1b]52;c;{}\x07", base64(text.as_bytes()))?;
+    stdout.flush()
+}
+
+/// Pipes `text` into the first available platform clipboard utility. Returns
+/// whether one ran successfully.
+fn native_copy(text: &str) -> bool {
+    clipboard_commands()
+        .iter()
+        .any(|(command, args)| pipe_to(command, args, text).is_ok())
+}
+
+fn clipboard_commands() -> &'static [(&'static str, &'static [&'static str])] {
+    if cfg!(target_os = "macos") {
+        &[("pbcopy", &[])]
+    } else if cfg!(target_os = "windows") {
+        &[("clip", &[])]
+    } else {
+        &[
+            ("wl-copy", &[]),
+            ("xclip", &["-selection", "clipboard"]),
+            ("xsel", &["-b"]),
+        ]
+    }
+}
+
+fn pipe_to(command: &str, args: &[&str], text: &str) -> io::Result<()> {
+    let mut child = Command::new(command)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("clipboard command has no stdin"))?
+        .write_all(text.as_bytes())?;
+
+    child.wait()?;
+    Ok(())
+}
+
+/// Standard base64 (RFC 4648) with `=` padding.
+fn base64(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    input
+        .chunks(3)
+        .flat_map(|chunk| {
+            let [a, b, c] = [
+                chunk[0],
+                *chunk.get(1).unwrap_or(&0),
+                *chunk.get(2).unwrap_or(&0),
+            ];
+            let triple = (a as u32) << 16 | (b as u32) << 8 | c as u32;
+            let indices = [
+                triple >> 18 & 0x3f,
+                triple >> 12 & 0x3f,
+                triple >> 6 & 0x3f,
+                triple & 0x3f,
+            ];
+            indices.into_iter().enumerate().map(move |(i, index)| {
+                // Pad the slots that have no source byte behind them.
+                if i > chunk.len() {
+                    b'='
+                } else {
+                    ALPHABET[index as usize]
+                }
+            })
+        })
+        .map(char::from)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::base64;
+
+    #[test]
+    fn test_base64_matches_known_vectors() {
+        let cases = [
+            ("", ""),
+            ("f", "Zg=="),
+            ("fo", "Zm8="),
+            ("foo", "Zm9v"),
+            ("foob", "Zm9vYg=="),
+            ("fooba", "Zm9vYmE="),
+            ("foobar", "Zm9vYmFy"),
+            ("hello world", "aGVsbG8gd29ybGQ="),
+        ];
+
+        cases
+            .into_iter()
+            .for_each(|(input, expected)| assert_eq!(base64(input.as_bytes()), expected));
+    }
+}

--- a/basalt/src/command.rs
+++ b/basalt/src/command.rs
@@ -93,6 +93,9 @@ pub(crate) enum Command {
     NoteEditorExperimentalCursorLeft,
     NoteEditorExperimentalCursorRight,
     NoteEditorInsertMode,
+    NoteEditorVisualMode,
+    NoteEditorVisualLineMode,
+    NoteEditorYank,
 
     VaultSelectorModalUp,
     VaultSelectorModalDown,
@@ -205,6 +208,9 @@ fn str_to_command(s: &str) -> Option<Command> {
         "note_editor_experimental_cursor_left" => Some(Command::NoteEditorExperimentalCursorLeft),
         "note_editor_experimental_cursor_right" => Some(Command::NoteEditorExperimentalCursorRight),
         "note_editor_insert_mode" => Some(Command::NoteEditorInsertMode),
+        "note_editor_visual_mode" => Some(Command::NoteEditorVisualMode),
+        "note_editor_visual_line_mode" => Some(Command::NoteEditorVisualLineMode),
+        "note_editor_yank" => Some(Command::NoteEditorYank),
 
         "vault_selector_modal_up" => Some(Command::VaultSelectorModalUp),
         "vault_selector_modal_down" => Some(Command::VaultSelectorModalDown),
@@ -392,6 +398,11 @@ impl From<Command> for Message<'_> {
                 Message::NoteEditor(note_editor::Message::CursorRight)
             }
             Command::NoteEditorInsertMode => Message::NoteEditor(note_editor::Message::InsertMode),
+            Command::NoteEditorVisualMode => Message::NoteEditor(note_editor::Message::VisualMode),
+            Command::NoteEditorVisualLineMode => {
+                Message::NoteEditor(note_editor::Message::VisualLineMode)
+            }
+            Command::NoteEditorYank => Message::NoteEditor(note_editor::Message::Yank),
 
             Command::VaultSelectorModalClose => {
                 Message::VaultSelectorModal(vault_selector_modal::Message::Close)

--- a/basalt/src/help.txt
+++ b/basalt/src/help.txt
@@ -187,8 +187,8 @@ INTERFACE
 
       LIMITATIONS:
         • No undo/redo support
-        • No clipboard operations (copy/paste/cut)
-        • No text selection
+        • No paste or cut (yank to clipboard is supported in vim mode)
+        • Text selection only via vim visual mode (‹v› / ‹V›, then ‹y›)
         • No multi-line deletion
         • No line/word deletion commands
         • No jumping to start/end of line or document
@@ -260,7 +260,9 @@ CONFIGURATION
     note_editor_experimental_set_edit_mode, note_editor_experimental_set_read_mode,
     note_editor_experimental_save, note_editor_experimental_exit_mode,
     note_editor_experimental_cursor_word_forward,
-    note_editor_experimental_cursor_word_backward
+    note_editor_experimental_cursor_word_backward,
+    note_editor_insert_mode, note_editor_visual_mode,
+    note_editor_visual_line_mode, note_editor_yank
 
   INPUT MODAL COMMANDS:
     input_modal_edit_mode, input_modal_accept, input_modal_cancel,

--- a/basalt/src/lib.rs
+++ b/basalt/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod cli;
+pub mod clipboard;
 pub mod command;
 pub mod config;
 pub mod debug_log;

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -1,20 +1,71 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::Range};
 
 use ratatui::{
     buffer::Buffer,
     layout::{Offset, Rect},
-    style::{Color, Stylize},
+    style::{Color, Style, Stylize},
     text::Line,
     widgets::{
         Block, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
         Widget,
     },
 };
+use unicode_width::UnicodeWidthChar;
 
 use crate::note_editor::{
     cursor::CursorWidget,
-    state::{NoteEditorState, View},
+    state::{NoteEditorState, SelectionMode, View},
+    viewport::Viewport,
+    virtual_document::VirtualLine,
 };
+
+const SELECTION_STYLE: Style = Style::new().reversed();
+const YANK_FLASH_STYLE: Style = Style::new().bg(Color::LightCyan);
+
+fn render_highlight(
+    buf: &mut Buffer,
+    inner_area: Rect,
+    viewport: &Viewport,
+    lines: &[VirtualLine],
+    meta_len: usize,
+    range: &Range<usize>,
+    style: Style,
+) {
+    let viewport_top = viewport.top() as usize;
+    let horizontal_scroll = viewport.left();
+
+    lines
+        .iter()
+        .enumerate()
+        .skip(viewport_top)
+        .take(inner_area.height as usize)
+        .filter(|(idx, _)| *idx >= meta_len)
+        .for_each(|(idx, line)| {
+            let y = inner_area.y + (idx - viewport_top) as u16;
+
+            line.virtual_spans()
+                .iter()
+                .fold(0u16, |col, span| match span.source_range() {
+                    Some(source_range) => span.char_indices().fold(col, |col, (byte_idx, ch)| {
+                        let width = ch.width().unwrap_or(0) as u16;
+                        if col >= horizontal_scroll
+                            && range.contains(&(source_range.start + byte_idx))
+                        {
+                            let cell = Rect::new(
+                                inner_area.x + col - horizontal_scroll,
+                                y,
+                                width.max(1),
+                                1,
+                            )
+                            .intersection(inner_area);
+                            buf.set_style(cell, style);
+                        }
+                        col + width
+                    }),
+                    None => col + span.width() as u16,
+                });
+        });
+}
 
 #[derive(Default)]
 pub struct NoteEditor<'a>(pub PhantomData<&'a ()>);
@@ -25,6 +76,12 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let (mode_label, mode_color) = match state.view {
             View::Edit(..) if state.vim_mode() && state.insert_mode() => ("INSERT", Color::Green),
+            View::Edit(..) if state.vim_mode() && state.is_selecting() => {
+                match state.selection().map(|selection| selection.mode) {
+                    Some(SelectionMode::Line) => ("V-LINE", Color::Magenta),
+                    _ => ("VISUAL", Color::Magenta),
+                }
+            }
             View::Edit(..) if state.vim_mode() => ("NORMAL", Color::Yellow),
             View::Edit(..) => ("EDIT", Color::Green),
             View::Read => ("READ", Color::Red),
@@ -84,6 +141,30 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
             .scroll((0, state.viewport().left()))
             .block(block)
             .render(area, buf);
+
+        if let Some(range) = state.selection_range() {
+            render_highlight(
+                buf,
+                inner_area,
+                state.viewport(),
+                &lines,
+                meta_lines_count,
+                &range,
+                SELECTION_STYLE,
+            );
+        }
+
+        if let Some(range) = state.yank_flash_range() {
+            render_highlight(
+                buf,
+                inner_area,
+                state.viewport(),
+                &lines,
+                meta_lines_count,
+                &range,
+                YANK_FLASH_STYLE,
+            );
+        }
 
         if !state.content.is_empty() || state.is_editing() {
             CursorWidget::default()

--- a/basalt/src/note_editor/mod.rs
+++ b/basalt/src/note_editor/mod.rs
@@ -20,7 +20,7 @@ use ratatui::{
 use crate::{
     app::{calc_scroll_amount, ActivePane, Message as AppMessage, ScrollAmount},
     explorer,
-    note_editor::state::{EditMode, NoteEditorState, View},
+    note_editor::state::{EditMode, NoteEditorState, SelectionMode, View},
     outline, toast,
 };
 
@@ -49,6 +49,9 @@ pub enum Message {
     JumpToBlock(usize),
     Delete,
     InsertMode,
+    VisualMode,
+    VisualLineMode,
+    Yank,
 }
 
 // FIXME: Add resize message to handle resize related updates like cursor positioning
@@ -156,8 +159,24 @@ pub fn update<'a>(
             // Normal mode (vim): navigation and read-mode equivalents
             Message::CursorWordForward => state.cursor_word_forward(),
             Message::CursorWordBackward => state.cursor_word_backward(),
-            Message::InsertMode | Message::EditView => state.set_insert_mode(true),
+            Message::VisualMode => state.toggle_selection(SelectionMode::Char),
+            Message::VisualLineMode => state.toggle_selection(SelectionMode::Line),
+            Message::Yank => {
+                if let Some(text) = state.selected_text() {
+                    if let Some(range) = state.selection_range() {
+                        state.flash_yank(range);
+                    }
+                    state.clear_selection();
+                    return Some(AppMessage::CopyToClipboard(text));
+                }
+            }
+            Message::Exit => state.clear_selection(),
+            Message::InsertMode | Message::EditView => {
+                state.clear_selection();
+                state.set_insert_mode(true);
+            }
             Message::ToggleView | Message::ReadView => {
+                state.clear_selection();
                 state.exit_insert();
                 state.set_view(View::Read);
                 return Some(AppMessage::UpdateSelectedNoteContent((
@@ -275,5 +294,55 @@ pub fn handle_editing_event(key: KeyEvent) -> Option<Message> {
             Some(Message::ToggleView)
         }
         _ => Some(Message::KeyEvent(key)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use ratatui::layout::Size;
+
+    use super::*;
+    use crate::{config::Symbols, note_editor::state::EditMode};
+
+    fn vim_edit_state(content: &str) -> NoteEditorState<'static> {
+        let mut state =
+            NoteEditorState::new(content, "test", Path::new("test.md"), &Symbols::unicode());
+        state.set_vim_mode(true);
+        state.resize_viewport(Size::new(40, 10));
+        state.set_view(View::Edit(EditMode::Source));
+        state
+    }
+
+    #[test]
+    fn test_yank_emits_copy_to_clipboard() {
+        let mut state = vim_edit_state("hello world\n");
+        let size = Size::new(40, 10);
+
+        update(Message::VisualMode, size, &mut state);
+        update(Message::CursorRight, size, &mut state);
+        update(Message::CursorRight, size, &mut state);
+        update(Message::CursorRight, size, &mut state);
+        update(Message::CursorRight, size, &mut state);
+
+        let message = update(Message::Yank, size, &mut state);
+
+        assert_eq!(
+            message,
+            Some(AppMessage::CopyToClipboard("hello".to_string()))
+        );
+        assert!(!state.is_selecting(), "yank should clear the selection");
+        assert_eq!(
+            state.yank_flash_range(),
+            Some(0..5),
+            "yank should flash the copied range"
+        );
+    }
+
+    #[test]
+    fn test_yank_without_selection_is_noop() {
+        let mut state = vim_edit_state("hello world\n");
+        assert_eq!(update(Message::Yank, Size::new(40, 10), &mut state), None);
     }
 }

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -1,8 +1,11 @@
 use std::{
+    borrow::Cow,
     fmt,
     fs::File,
     io::{self, Write},
+    ops::Range,
     path::{Path, PathBuf},
+    time::{Duration, Instant},
 };
 
 use ratatui::layout::Size;
@@ -37,6 +40,28 @@ pub enum View {
     Edit(EditMode),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SelectionMode {
+    Char,
+    Line,
+}
+
+/// `anchor` is the source byte offset where selection began; the moving end is
+/// the cursor's current source offset.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Selection {
+    pub anchor: usize,
+    pub mode: SelectionMode,
+}
+
+const YANK_FLASH_DURATION: Duration = Duration::from_millis(150);
+
+#[derive(Clone, Debug)]
+struct YankFlash {
+    range: Range<usize>,
+    started: Instant,
+}
+
 impl fmt::Display for View {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -63,6 +88,8 @@ pub struct NoteEditorState<'a> {
     editor_enabled: bool,
     modified: bool,
     viewport: Viewport,
+    selection: Option<Selection>,
+    yank_flash: Option<YankFlash>,
     text_buffer: Option<TextBuffer>,
     /// Which block is currently in raw/edit mode. Stored explicitly so
     /// the layout always matches the text_buffer, even when the cursor
@@ -90,6 +117,8 @@ impl<'a> NoteEditorState<'a> {
             vim_mode: false,
             editor_enabled: false,
             modified: false,
+            selection: None,
+            yank_flash: None,
             editing_block: None,
         }
     }
@@ -376,6 +405,86 @@ impl<'a> NoteEditorState<'a> {
 
     pub fn modified(&self) -> bool {
         self.modified || self.text_buffer().is_some_and(|buffer| buffer.modified)
+    }
+
+    pub fn selection(&self) -> Option<Selection> {
+        self.selection
+    }
+
+    pub fn is_selecting(&self) -> bool {
+        self.selection.is_some()
+    }
+
+    /// Enters visual selection in `mode`, or exits if that mode is already active.
+    pub fn toggle_selection(&mut self, mode: SelectionMode) {
+        self.selection = match self.selection {
+            Some(selection) if selection.mode == mode => None,
+            _ => Some(Selection {
+                anchor: self.cursor.source_offset(),
+                mode,
+            }),
+        };
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.selection = None;
+    }
+
+    /// Source content as currently displayed, accounting for unsaved edits.
+    fn live_content(&self) -> Cow<'_, str> {
+        self.text_buffer
+            .as_ref()
+            .filter(|buffer| buffer.modified)
+            .map(|buffer| Cow::Owned(buffer.write(&self.content)))
+            .unwrap_or(Cow::Borrowed(&self.content))
+    }
+
+    /// Source byte range from anchor to cursor. Charwise includes the character
+    /// under the cursor; linewise rounds out to whole lines.
+    pub fn selection_range(&self) -> Option<Range<usize>> {
+        let selection = self.selection?;
+        let content = self.live_content();
+        let cursor = self.cursor.source_offset().min(content.len());
+        let anchor = selection.anchor.min(content.len());
+        let (lo, hi) = (anchor.min(cursor), anchor.max(cursor));
+
+        let range = match selection.mode {
+            SelectionMode::Char => {
+                let end = hi + content[hi..].chars().next().map_or(0, char::len_utf8);
+                lo..end
+            }
+            SelectionMode::Line => {
+                let start = content[..lo].rfind('\n').map_or(0, |i| i + 1);
+                let end = content[hi..]
+                    .find('\n')
+                    .map_or(content.len(), |i| hi + i + 1);
+                start..end
+            }
+        };
+
+        Some(range)
+    }
+
+    pub fn selected_text(&self) -> Option<String> {
+        let range = self.selection_range()?;
+        self.live_content().get(range).map(str::to_string)
+    }
+
+    /// Flashes `range` to acknowledge a yank. The highlight fades on its own
+    /// after [`YANK_FLASH_DURATION`].
+    pub fn flash_yank(&mut self, range: Range<usize>) {
+        self.yank_flash = Some(YankFlash {
+            range,
+            started: Instant::now(),
+        });
+    }
+
+    /// The range to flash right now, or `None` once the flash has elapsed.
+    pub fn yank_flash_range(&self) -> Option<Range<usize>> {
+        self.yank_flash
+            .as_ref()
+            .filter(|flash| flash.started.elapsed() < YANK_FLASH_DURATION)
+            .map(|flash| flash.range.clone())
     }
 
     pub fn cursor_word_forward(&mut self) {
@@ -1197,5 +1306,56 @@ mod tests {
             "non-active code background ({non_active_width}) must cover the \
              viewport ({left} + {width})",
         );
+    }
+
+    fn edit_state(content: &str) -> NoteEditorState<'static> {
+        let mut state =
+            NoteEditorState::new(content, "test", Path::new("test.md"), &Symbols::unicode());
+        state.resize_viewport(Size::new(40, 10));
+        state.set_view(View::Edit(EditMode::Source));
+        state
+    }
+
+    #[test]
+    fn test_charwise_selection_is_inclusive() {
+        let mut state = edit_state("hello world\n");
+
+        state.toggle_selection(SelectionMode::Char);
+        state.cursor_right(4);
+
+        assert_eq!(state.selected_text().as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn test_charwise_selection_extends_backwards() {
+        let mut state = edit_state("hello world\n");
+
+        state.cursor_right(4);
+        state.toggle_selection(SelectionMode::Char);
+        state.cursor_left(4);
+
+        assert_eq!(state.selected_text().as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn test_linewise_selection_covers_whole_line() {
+        let mut state = edit_state("line one\nline two\n");
+
+        state.cursor_right(3);
+        state.toggle_selection(SelectionMode::Line);
+
+        assert_eq!(state.selected_text().as_deref(), Some("line one\n"));
+    }
+
+    #[test]
+    fn test_toggle_same_mode_clears_selection() {
+        let mut state = edit_state("hello\n");
+
+        state.toggle_selection(SelectionMode::Char);
+        assert!(state.is_selecting());
+
+        state.toggle_selection(SelectionMode::Char);
+        assert!(!state.is_selecting());
+        assert_eq!(state.selection_range(), None);
     }
 }

--- a/basalt/vim.toml
+++ b/basalt/vim.toml
@@ -16,6 +16,10 @@ key_bindings = [
 
   # Experimental editor
   { key = "i", command = "note_editor_insert_mode" },
+  { key = "v", command = "note_editor_visual_mode" },
+  { key = "V", command = "note_editor_visual_line_mode" },
+  { key = "y", command = "note_editor_yank" },
+  { key = "esc", command = "note_editor_experimental_exit" },
   { key = "ctrl+e", command = "note_editor_experimental_toggle_view" },
   { key = "shift+r", command = "note_editor_experimental_set_read_view" },
   { key = "ctrl+x", command = "note_editor_experimental_save" },


### PR DESCRIPTION
Add vim-style visual selection to the note editor.

## What
- `v` (charwise) and `V` (linewise) enter visual selection, `y` yanks to the clipboard, `esc` cancels.
- A brief flash highlights the yanked range to acknowledge the copy.
- Selection is highlighted per character and clipped to the editor viewport.
- Clipboard writes use a native utility (`pbcopy`, `wl-copy`, `xclip`, `xsel`, `clip`) with an OSC 52 fallback for SSH and tmux, adding no new dependencies.

Opt-in via `vim_mode = true`. Bindings live in `vim.toml`.

Closes #573. Part of #94.