### PR TITLE
Split in-range Cargo updates into individual Renovate PRs

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -6,6 +6,7 @@
     "schedule:daily"
   ],
   "rebaseWhen": "behind-base-branch",
+  "rangeStrategy": "update-lockfile",
   "onboarding": false,
   "commitBodyTable": true,
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
## Summary

Sets `rangeStrategy` to `update-lockfile` in `renovate-config.json` so that dependency updates already satisfied by the existing `Cargo.toml` caret ranges (serde, ratatui, thiserror, tracing, toml, …) open as **one PR per crate**, touching only `Cargo.lock`.

Previously these in-range bumps produced no individual PRs — they were only swept into the weekly `lockFileMaintenance` PR, so day-to-day it looked like Renovate wasn't proposing anything. The manifest caret ranges are left untouched; only the lockfile changes in each PR.

`lockFileMaintenance` stays enabled (now largely redundant, still useful for purely-transitive crates). Expect the backlog of ~9 compatible bumps to trickle in at the default hourly/concurrent PR limits.

## Checklist

- [ ] I ran `make check` (format, clippy, tests, build)
- [x] I added a `Changelog:` trailer if this should appear in the changelog (n/a — CI tooling, not user-facing)
- [x] I have read and agree to the [Contributor License Agreement](../CLA.md)