### PR TITLE
Fix build on Android targets

### DIFF
--- a/basalt-core/CHANGELOG.md
+++ b/basalt-core/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.10.0](https://github.com/erikjuhani/basalt/releases/tag/basalt-core/0.10.0) (Jul, 26 2026)
+
+### Breaking
+
+- [1863417](https://github.com/erikjuhani/basalt/commit/1863417adfd88ba2f82b7879ea456054ef01d38f) Relicense: GPL-3.0 for app, Apache-2.0 for libraries; add CLA by @erikjuhani
+
+> Move off MIT to a split model that protects against proprietary forks
+> while keeping the libraries reusable.
+>
+> - basalt-tui: MIT -> GPL-3.0-or-later (copyleft and patent grant)
+> - basalt-core and basalt-widgets: MIT -> Apache-2.0 (permissive,
+>   reusable, with a patent grant)
+>
+> Add a lightweight Contributor License Agreement so future GPL
+> contributions can still be relicensed, including under a commercial
+> license, without chasing past contributors for sign-off. Contributors
+> keep their copyright and agree by opening a pull request.
+>
+> Document the split in the README and CONTRIBUTING, and add a pull
+> request template that acknowledges the CLA.
+>
+> Already-published versions remain MIT for anyone who has them; the new
+> terms apply from the next release onward.
+
+### Fixed
+
+- [7f5a34c](https://github.com/erikjuhani/basalt/commit/7f5a34c4a7efebc84af2aa69866dfb0e0e608c42) Fix build on Android targets
+
+> Rust treats `android` as a `target_os` distinct from `linux`, so the cfg
+> lists in `obsidian_global_config_locations` matched nothing on Android
+> and basalt-core failed to compile under Termux.
+>
+> Branch on the axis that matters instead of enumerating platforms: the
+> config directory name is a Windows capitalisation quirk, and the flatpak
+> and snap paths are Linux-only.
+
 ## [0.9.0](https://github.com/erikjuhani/basalt/releases/tag/basalt-core/0.9.0) (May, 14 2026)
 
 ### Breaking

--- a/basalt-core/src/obsidian/config.rs
+++ b/basalt-core/src/obsidian/config.rs
@@ -160,11 +160,11 @@ impl<'de> Deserialize<'de> for ObsidianConfig {
 ///
 /// More info: [https://help.obsidian.md/Files+and+folders/How+Obsidian+stores+data]
 pub fn obsidian_global_config_locations() -> Vec<PathBuf> {
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    const OBSIDIAN_CONFIG_DIR_NAME: &str = "obsidian";
-
     #[cfg(target_os = "windows")]
     const OBSIDIAN_CONFIG_DIR_NAME: &str = "Obsidian";
+
+    #[cfg(not(target_os = "windows"))]
+    const OBSIDIAN_CONFIG_DIR_NAME: &str = "obsidian";
 
     let override_path =
         env::var("OBSIDIAN_CONFIG_DIR")
@@ -176,9 +176,6 @@ pub fn obsidian_global_config_locations() -> Vec<PathBuf> {
 
     let default_config_path =
         config_dir().map(|config_path| config_path.join(OBSIDIAN_CONFIG_DIR_NAME));
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    let sandboxed_paths: [Option<PathBuf>; 0] = [];
 
     // In cases where user has a sandboxes instance of Obsidian installed under either flatpak or
     // snap, we must check if the configuration exists under these locations.
@@ -198,6 +195,9 @@ pub fn obsidian_global_config_locations() -> Vec<PathBuf> {
 
         [flatpak_path, snap_path]
     };
+
+    #[cfg(not(target_os = "linux"))]
+    let sandboxed_paths: [Option<PathBuf>; 0] = [];
 
     let base_paths = [override_path, default_config_path];
 


### PR DESCRIPTION
Basalt does not compile on Android, so `cargo install basalt-tui` fails under Termux.

Rust treats `android` as a `target_os` distinct from `linux`, and `obsidian_global_config_locations` enumerated its platforms positively (`any(macos, linux)` and `any(macos, windows)`). On Android neither arm matched, leaving `OBSIDIAN_CONFIG_DIR_NAME` and `sandboxed_paths` undefined and failing the build with two `E0425`s.

The fix branches on the axis that actually matters rather than listing platforms: the config directory name is a Windows capitalisation quirk (`windows` / `not(windows)`), and the flatpak and snap paths are Linux-only (`linux` / `not(linux)`). Android falls into the `not` arms, resolving the XDG config directory like any other unix and getting no sandboxed paths, which is correct since neither package format exists there.

Verified with `cargo check --target aarch64-linux-android` and `--target armv7-linux-androideabi`: both reproduce the reported errors before the change and compile clean after.

No prebuilt Android binary is added. This only keeps the source compilable for people building in Termux themselves.

Closes #588