### PR TITLE
Preserve explorer cursor and selection across background vault rescans

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -4,33 +4,6 @@
 
 ### Added
 
-- [8f58061](https://github.com/erikjuhani/basalt/commit/8f5806145a422c2e6d3c23e2bb6fe9bd55001f58) Render callout block quotes by @erikjuhani
-
-> Render Obsidian and GitHub callouts (`> [!note]`) with a per-kind
-> coloured bar and an icon + title header above the body, keeping the
-> accent colour while editing.
->
-> Support the full Obsidian type set (note, abstract, info, todo, tip,
-> success, question, warning, failure, danger, bug, example, quote) and
-> their aliases, plus custom titles and fold markers (`[!note]- Title`),
-> which pulldown-cmark does not recognise. Type names are case-insensitive
-> and unknown types fall back to note, as in Obsidian.
->
-> Each type has a configurable symbol across the ascii, unicode and nerd
-> font presets.
-
-- [00430a8](https://github.com/erikjuhani/basalt/commit/00430a85d15c49a0b6d5ea81038608ab15abe57d) Add vim visual selection with clipboard yank by @erikjuhani
-
-> Visual selection comes to the vim-mode note editor. `v` starts a
-> charwise selection and `V` a linewise one, motions extend it, `y` yanks
-> the selection to the system clipboard and `esc` cancels. A brief flash
-> marks the yanked range, and the highlight is painted per character and
-> clipped to the editor viewport.
->
-> Clipboard writes use the platform utility (pbcopy, wl-copy, xclip, xsel
-> or clip) with an OSC 52 fallback for SSH and tmux, so no new dependency
-> is added.
-
 - [1b66afd](https://github.com/erikjuhani/basalt/commit/1b66afdca6c036072981332877fa04b9a6610035) Pan viewport horizontally to follow the cursor in edit mode by @erikjuhani
 
 > Long source lines are shown raw (unwrapped) while editing, so the cursor
@@ -44,7 +17,7 @@
 > `width + offset`, covering every visible block, not just the one being
 > edited.
 
-- [51d9f92](https://github.com/erikjuhani/basalt/commit/51d9f92a834f1e30c84edaee380d6f7e9d168052) Add markdown table rendering to the note editor
+- [51d9f92](https://github.com/erikjuhani/basalt/commit/51d9f92a834f1e30c84edaee380d6f7e9d168052) Add markdown table rendering to the note editor by @erikjuhani
 
 > Tables were parsed away as paragraphs and never drawn. The note editor
 > now renders GFM tables as bordered boxes in reading view. Columns size
@@ -63,6 +36,33 @@
 > A thematic break is now kept as a plain paragraph instead of being
 > dropped, because a table whose pipes are deleted degrades into a bare
 > dash row that would otherwise vanish from the document.
+
+- [00430a8](https://github.com/erikjuhani/basalt/commit/00430a85d15c49a0b6d5ea81038608ab15abe57d) Add vim visual selection with clipboard yank by @erikjuhani
+
+> Add vim-style visual selection to the note editor: v (charwise) and V
+> (linewise) select text, y yanks the selection to the clipboard and esc
+> cancels. A brief flash highlights the yanked range to acknowledge the
+> copy.
+>
+> The selection is highlighted per character and clipped to the editor
+> viewport. Clipboard writes go through a native utility (pbcopy, wl-copy,
+> xclip, xsel or clip) with an OSC 52 fallback for SSH and tmux, adding no
+> new dependencies.
+
+- [8f58061](https://github.com/erikjuhani/basalt/commit/8f5806145a422c2e6d3c23e2bb6fe9bd55001f58) Render callout block quotes by @erikjuhani
+
+> Render Obsidian and GitHub callouts (`> [!note]`) with a per-kind
+> coloured bar and an icon + title header above the body, keeping the
+> accent colour while editing.
+>
+> Support the full Obsidian type set (note, abstract, info, todo, tip,
+> success, question, warning, failure, danger, bug, example, quote) and
+> their aliases, plus custom titles and fold markers (`[!note]- Title`),
+> which pulldown-cmark does not recognise. Type names are case-insensitive
+> and unknown types fall back to note, as in Obsidian.
+>
+> Each type has a configurable symbol across the ascii, unicode and nerd
+> font presets.
 
 ### Breaking
 
@@ -84,7 +84,34 @@
 > request template that acknowledges the CLA.
 >
 > Already-published versions remain MIT for anyone who has them; the new
-> terms take effect with this release (0.12.7).
+> terms apply from the next release onward.
+
+### Fixed
+
+- [1aa72d0](https://github.com/erikjuhani/basalt/commit/1aa72d00abe7e0bdb00aa883921422aae12dbb1d) Highlight prettified list markers in visual selection by @erikjuhani
+
+> Rendered list markers (and other leading synthetic glyphs like quote and
+> heading prefixes) carry no source range, so the selection highlight
+> skipped them and a selected line's marker was left blank. Highlight a
+> synthetic span when the content it precedes is selected, so the marker is
+> part of the selection.
+
+- [8e90558](https://github.com/erikjuhani/basalt/commit/8e90558b3041b90f5cd95b51aca0d1060d26bf05) Preserve explorer cursor and selection across background vault rescans
+
+> A background RescanVault fires whenever the debounced filesystem watcher
+> sees a relevant change, including the app's own autosave write to the
+> open note. Because a Note carries only a name and path, a content-only
+> write produces a structurally identical tree, yet the handler still
+> rebuilt the explorer and re-selected the open note's path. That snapped
+> the cursor back onto the open note whenever a watcher event landed while
+> the user had navigated away.
+>
+> Add ExplorerState::rescan, which no-ops when the flattened tree is
+> unchanged so a content-only write never touches the explorer. When the
+> structure does change it re-resolves the cursor and the open-note marker
+> independently by path, so neither snaps to the other.
+>
+> Fixes #589
 
 ## [0.12.6](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.12.6) (Jun, 21 2026)
 

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -498,8 +498,7 @@ impl<'a> App<'a> {
                 return Some(Message::SetActivePane(ActivePane::Explorer));
             }
             Message::RescanVault => {
-                let select = state.selected_note.as_ref().map(|note| note.path.clone());
-                state.explorer.with_entries(state.vault.entries(), select);
+                state.explorer.rescan(state.vault.entries());
                 debug!("rescanned vault after watcher change");
             }
             Message::CreateUntitledNote => {

--- a/basalt/src/explorer/item.rs
+++ b/basalt/src/explorer/item.rs
@@ -34,6 +34,13 @@ impl Item {
     pub(crate) fn is_dir(&self) -> bool {
         matches!(self, Self::Directory { .. })
     }
+
+    pub(crate) fn path(&self) -> PathBuf {
+        match self {
+            Self::Directory { path, .. } => path.clone(),
+            Self::File { note, .. } => note.path().to_path_buf(),
+        }
+    }
 }
 
 impl From<VaultEntry> for Item {

--- a/basalt/src/explorer/state.rs
+++ b/basalt/src/explorer/state.rs
@@ -189,15 +189,50 @@ impl ExplorerState {
         self.flatten_with_items(&items);
 
         if let Some(path) = select {
-            if let Some(index) = self.flat_items.iter().position(|(item, _)| match item {
-                Item::File { note, .. } => note.path() == path,
-                Item::Directory { path: dir_path, .. } => dir_path == &path,
-            }) {
+            if let Some(index) = self.index_of(&path) {
                 self.list_state.select(Some(index));
                 self.selected_item_index = Some(index);
                 self.selected_item_path = Some(path);
             }
         }
+    }
+
+    /// Refreshes entries from a background vault rescan while preserving what the user is
+    /// looking at. No-ops when the flattened tree is structurally unchanged: a content-only
+    /// write (the app's own autosave included) leaves the tree identical, so it must not
+    /// touch the explorer. When the structure genuinely changes, the cursor and the open-note
+    /// marker are re-resolved independently by path so neither snaps to the other.
+    pub fn rescan(&mut self, entries: Vec<VaultEntry>) {
+        let mut items: Vec<Item> = entries
+            .into_iter()
+            .map(|entry| self.map_to_item(0, entry))
+            .collect();
+        items.sort_by(sort_items_by(self.sort));
+        let flat_items: Vec<(Item, usize)> = items.iter().flat_map(flatten(self.sort, 0)).collect();
+
+        if flat_items == self.flat_items {
+            return;
+        }
+
+        let cursor_path = self.current_item().map(Item::path);
+        self.items = items;
+        self.flat_items = flat_items;
+
+        self.selected_item_index = self
+            .selected_item_path
+            .clone()
+            .and_then(|path| self.index_of(&path));
+
+        if let Some(index) = cursor_path.and_then(|path| self.index_of(&path)) {
+            self.list_state.select(Some(index));
+        }
+    }
+
+    fn index_of(&self, path: &Path) -> Option<usize> {
+        self.flat_items.iter().position(|(item, _)| match item {
+            Item::File { note, .. } => note.path() == path,
+            Item::Directory { path: dir_path, .. } => dir_path == path,
+        })
     }
 
     pub fn hide_pane(&mut self) {
@@ -413,5 +448,58 @@ mod tests {
         };
         assert_eq!(*depth, 0);
         assert_eq!(items[0].depth(), 1, "nested file should keep its depth");
+    }
+
+    fn note(name: &str) -> VaultEntry {
+        VaultEntry::File(Note::new_unchecked(
+            name,
+            &PathBuf::from(format!("{name}.md")),
+        ))
+    }
+
+    #[test]
+    fn rescan_does_not_move_cursor_when_structure_unchanged() {
+        let mut state = ExplorerState::default();
+        let entries = vec![note("a"), note("b"), note("c")];
+        // Open note `a`, then navigate the cursor away to `b`.
+        state.with_entries(entries.clone(), Some(PathBuf::from("a.md")));
+        state.list_state.select(Some(1));
+
+        // A content-only autosave produces an identical tree: nothing should move.
+        state.rescan(entries);
+
+        assert_eq!(state.list_state.selected(), Some(1), "cursor stays on `b`");
+        assert_eq!(
+            state.selected_item_path,
+            Some(PathBuf::from("a.md")),
+            "open-note marker stays on `a`"
+        );
+    }
+
+    #[test]
+    fn rescan_preserves_cursor_and_marker_by_identity_across_structural_change() {
+        let mut state = ExplorerState::default();
+        // Open note `b`, then navigate the cursor away to `c`.
+        state.with_entries(vec![note("b"), note("c")], Some(PathBuf::from("b.md")));
+        state.list_state.select(Some(1));
+
+        // Another process adds `a.md`, which sorts to the front and shifts every index.
+        state.rescan(vec![note("a"), note("b"), note("c")]);
+
+        assert_eq!(
+            state.list_state.selected(),
+            Some(2),
+            "cursor follows `c` to its new index instead of snapping to the open note"
+        );
+        assert_eq!(
+            state.selected_item_path,
+            Some(PathBuf::from("b.md")),
+            "open-note marker stays on `b` instead of jumping to the cursor"
+        );
+        assert_eq!(
+            state.selected_item_index,
+            Some(1),
+            "open-note index is re-resolved to `b`'s shifted position"
+        );
     }
 }


### PR DESCRIPTION
Fixes #589. An alternative to #590 that targets the root cause rather than the re-selection symptom.

## Root cause

`RescanVault` fires whenever the debounced filesystem watcher sees a relevant change, including the app's own autosave write to the open note. Since `Note` carries only a name and path, a content-only write produces a structurally identical tree, yet the handler unconditionally rebuilt the explorer and re-selected a path. That re-selection is what snapped the cursor.

So the trigger is a self-inflicted feedback loop: the app writes a file, its own watcher fires ~250ms later, and the rescan rebuilds an unchanged tree whose only observable effect is disturbing the explorer. `#590` swaps which path gets re-selected, which fixes the cursor but moves the open-note marker onto the cursor's item instead.

## Fix

Add `ExplorerState::rescan`, used only by the background `RescanVault` path:

- No-op when the flattened tree is structurally unchanged, so a content-only write (the app's own autosave included) never touches the explorer. This dissolves the reported repro at its source.
- When the structure genuinely changes, re-resolve the cursor and the open-note marker independently by path so neither snaps to the other.

`RefreshVault` (rename and create) still uses `with_entries` with an explicit `select`, since moving the selection to the acted-on item there is intended.

## Tests

Two new unit tests in `explorer/state.rs`:

- A content-only rescan leaves the cursor and the open-note marker where they were.
- A structural change that shifts every index keeps the cursor on its item and re-resolves the marker to the open note's new position.

Both fail under the old behavior and under #590.

## Verification

- `make fmt` clean, `cargo clippy` clean
- 105 unit tests and 2 doc-tests pass