### PR TITLE
Keep the vim cursor on a real character after word motions

### DIFF
--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -429,7 +429,7 @@ mod tests {
             .iter()
             .map(|span| match span {
                 VirtualSpan::Content(s, _)
-                | VirtualSpan::Synthetic(s)
+                | VirtualSpan::Synthetic(s, _)
                 | VirtualSpan::WrapMarker(s) => s.content.to_string(),
             })
             .collect();

--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -427,7 +427,7 @@ mod tests {
             .virtual_spans()
             .iter()
             .map(|span| match span {
-                VirtualSpan::Content(s, _) | VirtualSpan::Synthetic(s) => s.content.to_string(),
+                VirtualSpan::Content(s, _) | VirtualSpan::Synthetic(s, _) => s.content.to_string(),
             })
             .collect();
 

--- a/basalt/src/note_editor/mod.rs
+++ b/basalt/src/note_editor/mod.rs
@@ -279,6 +279,7 @@ fn operate_lines<'a>(
 }
 
 fn motion_to<'a>(state: &mut NoteEditorState, offset: usize) -> Option<AppMessage<'a>> {
+    let offset = motion::clamp_cursor(&state.content, offset);
     state.jump_to_offset(offset);
     select_at_cursor(state)
 }
@@ -792,6 +793,46 @@ mod tests {
 
         update(Message::CursorWordBackward, size, &mut state);
         assert_eq!(state.cursor.source_offset(), 4, "b lands on start of 'bar'");
+    }
+
+    #[test]
+    fn test_motion_onto_blank_separator_stays_consistent() {
+        // A motion landing on the blank line between two paragraphs must rest on
+        // that line: the cursor's row and the raw (editing) block stay in
+        // agreement instead of stranding the cursor while the next block renders
+        // raw. The blank line's source offset is 11 (the second newline).
+        for message in [Message::CursorWordForward, Message::ParagraphForward] {
+            let mut state = vim_edit_state("first para\n\nsecond para\n");
+            let size = Size::new(40, 10);
+
+            update(Message::CursorLineEnd, size, &mut state);
+            update(message.clone(), size, &mut state);
+
+            assert_eq!(
+                state.cursor.source_offset(),
+                11,
+                "{message:?} rests on the blank separator line"
+            );
+            assert_eq!(
+                state.editing_block(),
+                Some(state.current_block_idx()),
+                "{message:?}: the raw block matches the block the cursor sits in"
+            );
+        }
+    }
+
+    #[test]
+    fn test_word_forward_clamps_at_line_end() {
+        let mut state = vim_edit_state("foo bar baz\n");
+        let size = Size::new(40, 10);
+
+        update(Message::CursorLineEnd, size, &mut state);
+        update(Message::CursorWordForward, size, &mut state);
+        assert_eq!(
+            state.cursor.source_offset(),
+            10,
+            "w on the last word stays on 'z', not past the row"
+        );
     }
 
     #[test]

--- a/basalt/src/note_editor/mod.rs
+++ b/basalt/src/note_editor/mod.rs
@@ -277,6 +277,7 @@ fn operate_lines<'a>(
 }
 
 fn motion_to<'a>(state: &mut NoteEditorState, offset: usize) -> Option<AppMessage<'a>> {
+    let offset = motion::clamp_cursor(&state.content, offset);
     state.jump_to_offset(offset);
     select_at_cursor(state)
 }
@@ -780,6 +781,46 @@ mod tests {
 
         update(Message::CursorWordBackward, size, &mut state);
         assert_eq!(state.cursor.source_offset(), 4, "b lands on start of 'bar'");
+    }
+
+    #[test]
+    fn test_motion_onto_blank_separator_stays_consistent() {
+        // A motion landing on the blank line between two paragraphs must rest on
+        // that line: the cursor's row and the raw (editing) block stay in
+        // agreement instead of stranding the cursor while the next block renders
+        // raw. The blank line's source offset is 11 (the second newline).
+        for message in [Message::CursorWordForward, Message::ParagraphForward] {
+            let mut state = vim_edit_state("first para\n\nsecond para\n");
+            let size = Size::new(40, 10);
+
+            update(Message::CursorLineEnd, size, &mut state);
+            update(message.clone(), size, &mut state);
+
+            assert_eq!(
+                state.cursor.source_offset(),
+                11,
+                "{message:?} rests on the blank separator line"
+            );
+            assert_eq!(
+                state.editing_block(),
+                Some(state.current_block_idx()),
+                "{message:?}: the raw block matches the block the cursor sits in"
+            );
+        }
+    }
+
+    #[test]
+    fn test_word_forward_clamps_at_line_end() {
+        let mut state = vim_edit_state("foo bar baz\n");
+        let size = Size::new(40, 10);
+
+        update(Message::CursorLineEnd, size, &mut state);
+        update(Message::CursorWordForward, size, &mut state);
+        assert_eq!(
+            state.cursor.source_offset(),
+            10,
+            "w on the last word stays on 'z', not past the row"
+        );
     }
 
     #[test]

--- a/basalt/src/note_editor/motion.rs
+++ b/basalt/src/note_editor/motion.rs
@@ -92,6 +92,20 @@ pub fn first_nonblank(content: &str, offset: usize) -> usize {
         .map_or(start, |(i, _)| start + i)
 }
 
+pub fn clamp_cursor(content: &str, offset: usize) -> usize {
+    let offset = offset.min(content.len());
+    let offset = if offset == content.len() && content.ends_with('\n') {
+        offset - 1
+    } else {
+        offset
+    };
+    match content[offset..].chars().next() {
+        Some(c) if c != '\n' => offset,
+        _ if line_start(content, offset) == offset => offset,
+        _ => prev_char_offset(content, offset),
+    }
+}
+
 pub fn word_forward(content: &str, offset: usize, big: bool) -> usize {
     let mut chars = chars_from(content, offset).peekable();
     let Some(&(_, first)) = chars.peek() else {
@@ -505,6 +519,17 @@ mod tests {
         assert_eq!(word_forward(text, 4, false), 8); // 'baz'
                                                      // WORD mode skips the punctuation as part of the word.
         assert_eq!(word_forward(text, 0, true), 8); // 'baz'
+    }
+
+    #[test]
+    fn clamp_cursor_pulls_back_from_line_and_buffer_ends() {
+        assert_eq!(clamp_cursor("foo bar baz\n", 12), 10);
+        assert_eq!(clamp_cursor("foo bar baz", 11), 10);
+        assert_eq!(clamp_cursor("foo\nbar", 3), 2);
+        assert_eq!(clamp_cursor("foo\n\nbar", 4), 4);
+        assert_eq!(clamp_cursor("foo\n\n", 5), 4);
+        assert_eq!(clamp_cursor("", 0), 0);
+        assert_eq!(clamp_cursor("foo bar", 4), 4);
     }
 
     #[test]

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -219,6 +219,10 @@ impl<'a> NoteEditorState<'a> {
         self.text_buffer.as_ref()
     }
 
+    pub fn editing_block(&self) -> Option<usize> {
+        self.editing_block
+    }
+
     pub fn enter_insert(&mut self, block_idx: usize) {
         // Commit any pending edits from the previous block before switching.
         self.commit_text_buffer();
@@ -853,19 +857,31 @@ impl<'a> NoteEditorState<'a> {
         let offset = cursor::snap_to_char_boundary(&self.content, offset);
 
         if matches!(self.view, View::Edit(..)) {
+            let preceding = || {
+                self.ast_nodes
+                    .iter()
+                    .rposition(|node| node.source_range().end <= offset)
+            };
+            let following = || {
+                self.ast_nodes
+                    .iter()
+                    .position(|node| node.source_range().start >= offset)
+            };
             let target_block = self
                 .ast_nodes
                 .iter()
                 .position(|node| node.source_range().contains(&offset))
                 .or_else(|| {
-                    self.ast_nodes
-                        .iter()
-                        .position(|node| node.source_range().start >= offset)
-                })
-                .or_else(|| {
-                    self.ast_nodes
-                        .iter()
-                        .rposition(|node| node.source_range().end <= offset)
+                    // Outside every block: a blank separator line belongs to the
+                    // preceding block, while leading whitespace belongs to the
+                    // block it indents. Prefer accordingly, fall back the other way.
+                    let on_blank_line =
+                        offset == self.content.len() || self.content[offset..].starts_with('\n');
+                    if on_blank_line {
+                        preceding().or_else(following)
+                    } else {
+                        following().or_else(preceding)
+                    }
                 });
             if let Some(block) = target_block {
                 if self.editing_block != Some(block) {

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -281,6 +281,10 @@ impl<'a> NoteEditorState<'a> {
         self.text_buffer.as_ref()
     }
 
+    pub fn editing_block(&self) -> Option<usize> {
+        self.editing_block
+    }
+
     fn block_source_range(&self, block_idx: usize) -> Option<Range<usize>> {
         let node = self.ast_nodes.get(block_idx)?;
         let start = if block_idx == 0 {

--- a/basalt/src/note_editor/virtual_document.rs
+++ b/basalt/src/note_editor/virtual_document.rs
@@ -29,7 +29,7 @@ macro_rules! content_span {
 
 macro_rules! synthetic_span {
     ($span:expr) => {{
-        VirtualSpan::Synthetic($span.clone().into())
+        VirtualSpan::Synthetic($span.clone().into(), None)
     }};
 }
 
@@ -52,16 +52,14 @@ pub(crate) use virtual_line;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum VirtualSpan<'a> {
-    Synthetic(Span<'a>),
+    Synthetic(Span<'a>, Option<SourceRange<usize>>),
     Content(Span<'a>, SourceRange<usize>),
 }
 
 impl VirtualSpan<'_> {
     pub fn contains_offset(&self, offset: usize) -> bool {
-        match self {
-            VirtualSpan::Content(_, source_range) => source_range.contains(&offset),
-            _ => false,
-        }
+        self.source_range()
+            .is_some_and(|range| range.contains(&offset))
     }
 
     pub fn chars(&self) -> Chars<'_> {
@@ -81,13 +79,13 @@ impl VirtualSpan<'_> {
     pub fn source_range(&self) -> Option<&SourceRange<usize>> {
         match self {
             Self::Content(.., source_range) => Some(source_range),
-            Self::Synthetic(..) => None,
+            Self::Synthetic(.., source_range) => source_range.as_ref(),
         }
     }
 
     pub fn width(&self) -> usize {
         let span = match self {
-            VirtualSpan::Content(span, ..) | VirtualSpan::Synthetic(span) => span,
+            VirtualSpan::Content(span, ..) | VirtualSpan::Synthetic(span, ..) => span,
         };
         // A tab is one byte but rendered as two columns (expanded at draw time).
         span.content
@@ -104,7 +102,7 @@ impl VirtualSpan<'_> {
 impl<'a> From<VirtualSpan<'a>> for Span<'a> {
     fn from(value: VirtualSpan<'a>) -> Self {
         let span = match value {
-            VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => span,
+            VirtualSpan::Synthetic(span, _) | VirtualSpan::Content(span, _) => span,
         };
         // Expand tabs so the terminal doesn't break the layout; the cursor maps
         // by byte offset against the un-expanded content (tabs counted as two).
@@ -350,8 +348,9 @@ impl<'a> VirtualDocument<'a> {
                     // Append empty rows so on-screen spacing mirrors the source:
                     // blanks already inside the block, plus blanks in the gap to
                     // the next block. The last block gets one trailing row.
-                    let trailing = match ast_nodes.get(idx + 1) {
-                        None => 1,
+                    match ast_nodes.get(idx + 1) {
+                        // Padding past the final block; it maps to no source line.
+                        None => block.lines.push(empty_virtual_line!()),
                         Some(next) => {
                             let absorbed = if is_active {
                                 0
@@ -365,13 +364,25 @@ impl<'a> VirtualDocument<'a> {
                             // The first newline only terminates the block's last
                             // line unless that line already ended with one.
                             let terminator = !slice.ends_with('\n') as usize;
-                            absorbed + gap_blanks.saturating_sub(terminator)
-                        }
-                    };
 
-                    block
-                        .lines
-                        .extend((0..trailing).map(|_| empty_virtual_line!()));
+                            // Blanks absorbed from inside the block carry no gap
+                            // position; the blank lines in the gap to the next block
+                            // are real, navigable empty lines at their own offset.
+                            block
+                                .lines
+                                .extend((0..absorbed).map(|_| empty_virtual_line!()));
+                            let first = end + terminator;
+                            block
+                                .lines
+                                .extend((0..gap_blanks.saturating_sub(terminator)).map(|i| {
+                                    let at = first + i;
+                                    virtual_line!([VirtualSpan::Synthetic(
+                                        Span::default(),
+                                        Some(at..at + 1),
+                                    )])
+                                }));
+                        }
+                    }
                 }
 
                 let block_lines = block.lines.clone();

--- a/basalt/src/note_editor/virtual_document.rs
+++ b/basalt/src/note_editor/virtual_document.rs
@@ -30,7 +30,7 @@ macro_rules! content_span {
 
 macro_rules! synthetic_span {
     ($span:expr) => {{
-        VirtualSpan::Synthetic($span.clone().into())
+        VirtualSpan::Synthetic($span.clone().into(), None)
     }};
 }
 
@@ -60,17 +60,15 @@ pub(crate) use wrap_marker_span;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum VirtualSpan<'a> {
-    Synthetic(Span<'a>),
+    Synthetic(Span<'a>, Option<SourceRange<usize>>),
     WrapMarker(Span<'a>),
     Content(Span<'a>, SourceRange<usize>),
 }
 
 impl VirtualSpan<'_> {
     pub fn contains_offset(&self, offset: usize) -> bool {
-        match self {
-            VirtualSpan::Content(_, source_range) => source_range.contains(&offset),
-            _ => false,
-        }
+        self.source_range()
+            .is_some_and(|range| range.contains(&offset))
     }
 
     pub fn chars(&self) -> Chars<'_> {
@@ -90,14 +88,15 @@ impl VirtualSpan<'_> {
     pub fn source_range(&self) -> Option<&SourceRange<usize>> {
         match self {
             Self::Content(.., source_range) => Some(source_range),
-            Self::Synthetic(..) | Self::WrapMarker(..) => None,
+            Self::Synthetic(.., source_range) => source_range.as_ref(),
+            Self::WrapMarker(..) => None,
         }
     }
 
     pub fn width(&self) -> usize {
         let span = match self {
             VirtualSpan::Content(span, ..)
-            | VirtualSpan::Synthetic(span)
+            | VirtualSpan::Synthetic(span, ..)
             | VirtualSpan::WrapMarker(span) => span,
         };
         // A tab is one byte but rendered as two columns (expanded at draw time).
@@ -122,7 +121,7 @@ impl VirtualSpan<'_> {
 impl<'a> From<VirtualSpan<'a>> for Span<'a> {
     fn from(value: VirtualSpan<'a>) -> Self {
         let span = match value {
-            VirtualSpan::Synthetic(span)
+            VirtualSpan::Synthetic(span, _)
             | VirtualSpan::WrapMarker(span)
             | VirtualSpan::Content(span, _) => span,
         };
@@ -439,8 +438,9 @@ impl<'a> VirtualDocument<'a> {
                     // Append empty rows so on-screen spacing mirrors the source:
                     // blanks already inside the block, plus blanks in the gap to
                     // the next block. The last block gets one trailing row.
-                    let trailing = match ast_nodes.get(idx + 1) {
-                        None => 1,
+                    match ast_nodes.get(idx + 1) {
+                        // Padding past the final block; it maps to no source line.
+                        None => block.lines.push(empty_virtual_line!()),
                         Some(next) => {
                             let absorbed = if is_active {
                                 0
@@ -454,13 +454,25 @@ impl<'a> VirtualDocument<'a> {
                             // The first newline only terminates the block's last
                             // line unless that line already ended with one.
                             let terminator = !slice.ends_with('\n') as usize;
-                            absorbed + gap_blanks.saturating_sub(terminator)
-                        }
-                    };
 
-                    block
-                        .lines
-                        .extend((0..trailing).map(|_| empty_virtual_line!()));
+                            // Blanks absorbed from inside the block carry no gap
+                            // position; the blank lines in the gap to the next block
+                            // are real, navigable empty lines at their own offset.
+                            block
+                                .lines
+                                .extend((0..absorbed).map(|_| empty_virtual_line!()));
+                            let first = end + terminator;
+                            block
+                                .lines
+                                .extend((0..gap_blanks.saturating_sub(terminator)).map(|i| {
+                                    let at = first + i;
+                                    virtual_line!([VirtualSpan::Synthetic(
+                                        Span::default(),
+                                        Some(at..at + 1),
+                                    )])
+                                }));
+                        }
+                    }
                 }
 
                 let block_lines = block.lines.clone();


### PR DESCRIPTION
## Problem

Two normal-mode `w` bugs in the note editor:

1. `w` on the last word of a line moved the cursor **past the end of the row**, since `word_forward` returns `content.len()` (past the trailing newline) when there is no next word.
2. `w` (and `}`) landing on the blank line between two paragraphs **stranded the cursor on the previous row while the next block rendered raw**. The separator was a synthetic virtual line with no source range, so `source_offset_to_virtual_line` returned `None`, the cursor's row went stale, and `jump_to_offset` flipped the next block to raw.

## Fix

- `motion::clamp_cursor` pulls a normal-mode target off a line-ending newline or the buffer end back onto the line's last character. Empty lines keep their position. Applied in `motion_to`, so only plain cursor moves are affected (operators and insert-mode motions are untouched).
- The blank line in the gap between two blocks now gets a real source range instead of a positionless synthetic line, so the cursor maps onto it. `VirtualSpan::Synthetic` carries an optional range; rendering is unchanged (an empty line renders the same either way, snapshots are untouched).
- `jump_to_offset` resolves the editing block to the one that owns the blank line (the preceding block for a separator, the following block for leading indentation), so the cursor's row and the raw block agree.

## Tests

- `clamp_cursor` unit coverage including empty-line and trailing-newline edges.
- `w` on the last word stays on the last character.
- `w` and `}` onto a paragraph separator rest on the blank line with a consistent row and editing block.

`make check` passes (fmt, clippy, tests, build).