### PR TITLE
Keep explorer cursor and selection stable across background rescans

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -191,6 +191,18 @@
 > last line never rises above the bottom, keeping as much content below the
 > heading visible as possible.
 
+- [50198c0](https://github.com/erikjuhani/basalt/commit/50198c0ccccbf4fc914e962254abf853f4355977) Keep explorer cursor and selection stable across background rescans by @erikjuhani
+
+> The debounced vault watcher fired a rescan roughly 250ms after picking a
+> note, which rebuilt the tree and snapped the explorer cursor back to the
+> active note. Moving the cursor right after selecting caused it to jump
+> back once loading finished.
+>
+> Split the rebuild into an intentional-select path (used on create and
+> rename) and a new refresh_entries that captures the cursor and the picked
+> note by path before rebuilding and restores each independently, so a
+> background rescan snaps neither.
+
 ## [0.12.6](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.12.6) (Jun, 21 2026)
 
 ### Added

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -609,11 +609,7 @@ impl<'a> App<'a> {
                 return Some(Message::SetActivePane(ActivePane::Explorer));
             }
             Message::RescanVault => {
-                let select = state
-                    .tabs
-                    .active_note()
-                    .map(|note| note.path().to_path_buf());
-                state.explorer.with_entries(state.vault.entries(), select);
+                state.explorer.refresh_entries(state.vault.entries());
                 debug!("rescanned vault after watcher change");
             }
             Message::CreateUntitledNote => {

--- a/basalt/src/explorer/state.rs
+++ b/basalt/src/explorer/state.rs
@@ -181,23 +181,42 @@ impl ExplorerState {
     }
 
     pub fn with_entries(&mut self, entries: Vec<VaultEntry>, select: Option<PathBuf>) {
+        self.rebuild(entries);
+
+        if let Some(index) = select.as_deref().and_then(|path| self.index_of(path)) {
+            self.list_state.select(Some(index));
+            self.selected_item_index = Some(index);
+            self.selected_item_path = select;
+        }
+    }
+
+    /// Rebuilds the tree from a background rescan, preserving the cursor and the
+    /// picked note independently so an async vault change snaps neither one.
+    pub fn refresh_entries(&mut self, entries: Vec<VaultEntry>) {
+        let cursor = self.current_item().map(|item| item.path().to_path_buf());
+        let picked = self.selected_item_path.clone();
+
+        self.rebuild(entries);
+
+        if let Some(index) = cursor.as_deref().and_then(|path| self.index_of(path)) {
+            self.list_state.select(Some(index));
+        }
+        self.selected_item_index = picked.as_deref().and_then(|path| self.index_of(path));
+        self.selected_item_path = picked;
+    }
+
+    fn rebuild(&mut self, entries: Vec<VaultEntry>) {
         let items: Vec<Item> = entries
             .into_iter()
             .map(|entry| self.map_to_item(0, entry))
             .collect();
-
         self.flatten_with_items(&items);
+    }
 
-        if let Some(path) = select {
-            if let Some(index) = self.flat_items.iter().position(|(item, _)| match item {
-                Item::File { note, .. } => note.path() == path,
-                Item::Directory { path: dir_path, .. } => dir_path == &path,
-            }) {
-                self.list_state.select(Some(index));
-                self.selected_item_index = Some(index);
-                self.selected_item_path = Some(path);
-            }
-        }
+    fn index_of(&self, path: &Path) -> Option<usize> {
+        self.flat_items
+            .iter()
+            .position(|(item, _)| item.path() == path)
     }
 
     pub fn reveal_path(&mut self, path: &Path) {


### PR DESCRIPTION
## Problem

Picking a note in the explorer and then immediately moving the cursor caused the cursor to jump back to the selected note once it finished loading. The debounced vault watcher fires a rescan roughly 250ms after selection, and the rescan rebuilt the tree and force-selected the active note, clobbering wherever the cursor had moved.

## Root cause

The explorer tracks two independent things: the **cursor** (`list_state`) and the **picked note** (`selected_item_path`, rendered bold and underlined). `with_entries` folded both into a single `select` argument, so a background rescan could only snap both to one item.

## Fix

- `with_entries` keeps its intentional-select behavior, still used on create and rename where moving both cursor and picked marker to the new item is correct.
- A new `refresh_entries` captures the cursor and the picked note by path before rebuilding, then restores each independently so a background rescan snaps neither. `RescanVault` now uses it.
- Factored the shared rebuild and index lookup into `rebuild` and `index_of` helpers.

## Testing

`make check` passes.