### PR TITLE
Add Homebrew install support

### DIFF
--- a/.github/scripts/homebrew-formula.sh
+++ b/.github/scripts/homebrew-formula.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Generate the Homebrew formula for basalt from the checksums of a release.
+#
+# Usage: homebrew-formula.sh VERSION CHECKSUM_DIR
+#
+# VERSION       release version without the leading "v", e.g. 0.12.7
+# CHECKSUM_DIR  directory holding the "*.tar.gz.sha256" files of the release
+#
+# Each checksum file is the output of `shasum -a 256 <archive>`, so the SHA is
+# its first whitespace separated field.
+
+set -euo pipefail
+
+version="${1:?version required}"
+checksum_dir="${2:?checksum directory required}"
+
+base_url="https://github.com/erikjuhani/basalt/releases/download/basalt/v${version}"
+
+sha256() {
+  local target="$1"
+  local file="${checksum_dir}/basalt-${version}-${target}.tar.gz.sha256"
+  awk '{ print $1 }' "${file}"
+}
+
+cat <<FORMULA
+class Basalt < Formula
+  desc "TUI application for Obsidian notes"
+  homepage "https://github.com/erikjuhani/basalt"
+  license "GPL-3.0-or-later"
+
+  on_macos do
+    on_arm do
+      url "${base_url}/basalt-${version}-aarch64-apple-darwin.tar.gz"
+      sha256 "$(sha256 aarch64-apple-darwin)"
+    end
+    on_intel do
+      url "${base_url}/basalt-${version}-x86_64-apple-darwin.tar.gz"
+      sha256 "$(sha256 x86_64-apple-darwin)"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "${base_url}/basalt-${version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "$(sha256 aarch64-unknown-linux-gnu)"
+    end
+    on_intel do
+      url "${base_url}/basalt-${version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "$(sha256 x86_64-unknown-linux-gnu)"
+    end
+  end
+
+  def install
+    bin.install "basalt"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/basalt --version")
+  end
+end
+FORMULA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,15 +90,18 @@ jobs:
 
           target="${MATRIX_TARGET}"
           bin_path="target/${target}/release"
-          archive="basalt-${version}-${target}"
+          staging="basalt-${version}-${target}"
+          mkdir -p "${staging}"
 
           if [ "${MATRIX_OS}" = "windows-latest" ]; then
-            archive="${archive}.zip"
-            7z a "${archive}" "${bin_path}/basalt.exe"
+            cp "${bin_path}/basalt.exe" "${staging}/"
+            archive="${staging}.zip"
+            7z a "${archive}" "${staging}"
             certutil -hashfile "${archive}" SHA256 > "${archive}.sha256"
           else
-            archive="${archive}.tar.gz"
-            tar -czf "${archive}" "${bin_path}/basalt"
+            cp "${bin_path}/basalt" "${staging}/"
+            archive="${staging}.tar.gz"
+            tar -czf "${archive}" "${staging}"
             shasum -a 256 "${archive}" > "${archive}.sha256"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,52 @@ jobs:
         run: |
           gh release upload "${REF_NAME}" ./release-artifacts/* --clobber
 
+  homebrew:
+    name: Update Homebrew tap
+    needs: release
+    if: ${{ !contains(inputs.tag || github.ref_name, '-') }}
+
+    environment: release
+
+    permissions: {}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Check out the tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: erikjuhani/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          persist-credentials: false
+          path: homebrew-tap
+
+      - name: Generate and commit the formula
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          REF_NAME: ${{ inputs.tag || github.ref_name }}
+        shell: bash
+        run: |
+          version="${REF_NAME##*/v}"
+
+          checksums="$(mktemp -d)"
+          gh release download "${REF_NAME}" --repo "${GITHUB_REPOSITORY}" \
+            --pattern '*.tar.gz.sha256' --dir "${checksums}"
+
+          mkdir -p homebrew-tap/Formula
+          .github/scripts/homebrew-formula.sh "${version}" "${checksums}" \
+            > homebrew-tap/Formula/basalt.rb
+
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/basalt.rb
+          git diff --cached --quiet && exit 0
+          git commit -m "basalt ${version}"
+          git push "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/erikjuhani/homebrew-tap.git" HEAD
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Basalt is a cross-platform TUI (Terminal User Interface) for managing Obsidian v
 
 ## Installation
 
+- Using [Homebrew](https://brew.sh):
+  ```sh
+  brew install erikjuhani/tap/basalt
+  ```
+
 - Using [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html):
   ```sh
   cargo install basalt-tui


### PR DESCRIPTION
Closes #120.

Adds a Homebrew tap install path so basalt can be installed with `brew install erikjuhani/tap/basalt`.

On each stable `basalt/v*` tag the release workflow generates a formula from the prebuilt release binaries and their checksums, then pushes it to the erikjuhani/homebrew-tap repository. The formula selects the matching macOS or Linux binary per architecture, so installing never compiles from source.

The build workflow now stages each binary in a versioned directory before archiving, so the tarball unpacks to a single top level folder and the formula can install the binary without referencing the build target path.
