### PR TITLE
Follow the link under the cursor with gx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "basalt-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "dirs",
  "indoc",
@@ -128,7 +128,7 @@ dependencies = [
 name = "basalt-tui"
 version = "0.13.0"
 dependencies = [
- "basalt-core 0.9.0",
+ "basalt-core 0.10.0",
  "clap",
  "crossterm",
  "etcetera",

--- a/basalt-core/CHANGELOG.md
+++ b/basalt-core/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
-## [0.10.0](https://github.com/erikjuhani/basalt/releases/tag/basalt-core/0.10.0) (Jul, 26 2026)
+## [0.10.0](https://github.com/erikjuhani/basalt/releases/tag/basalt-core/0.10.0) (Sep, 01 2026)
+
+### Added
+
+- [459d9bd](https://github.com/erikjuhani/basalt/commit/459d9bdb0f69fabb216b72e32a3c929daf1f136c) Follow the link under the cursor with gx
+
+> Add a note editor action that resolves whatever link sits under the
+> cursor. A wiki link travels to its note, creating the note first when it
+> does not exist yet. A bare URL or a [label](url) markdown link opens in
+> the platform browser.
+>
+> A single pure scan (motion::link_at) classifies the cursor position into
+> a LinkTarget, which app.rs resolves against the vault (new
+> Vault::find_note) or hands to a cross-platform opener (command::open_url).
+>
+> Bound to gx in the vim config and to enter and gd in the default config.
 
 ### Breaking
 
@@ -26,7 +41,7 @@
 
 ### Fixed
 
-- [7f5a34c](https://github.com/erikjuhani/basalt/commit/7f5a34c4a7efebc84af2aa69866dfb0e0e608c42) Fix build on Android targets
+- [7f5a34c](https://github.com/erikjuhani/basalt/commit/7f5a34c4a7efebc84af2aa69866dfb0e0e608c42) Fix build on Android targets by @erikjuhani
 
 > Rust treats `android` as a `target_os` distinct from `linux`, so the cfg
 > lists in `obsidian_global_config_locations` matched nothing on Android

--- a/basalt-core/Cargo.toml
+++ b/basalt-core/Cargo.toml
@@ -6,7 +6,7 @@ Provides the core functionality for Basalt TUI application
 readme = "README.md"
 repository = "https://github.com/erikjuhani/basalt"
 license = "Apache-2.0"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]

--- a/basalt-core/src/obsidian/vault.rs
+++ b/basalt-core/src/obsidian/vault.rs
@@ -121,19 +121,9 @@ pub fn update_wiki_links(
         }
     }
 
-    fn entry_to_note(entry: VaultEntry) -> Vec<Note> {
-        match entry {
-            VaultEntry::File(note) => vec![note],
-            VaultEntry::Directory { entries, .. } => {
-                entries.into_iter().flat_map(entry_to_note).collect()
-            }
-        }
-    }
-
     vault
-        .entries()
+        .notes()
         .into_iter()
-        .flat_map(entry_to_note)
         .try_for_each(replace_wiki_link(&replacements))?;
 
     Ok(())
@@ -606,6 +596,46 @@ impl Vault {
                 .collect(),
             _ => vec![],
         }
+    }
+
+    /// Returns every note in the vault, recursively flattened from [`Vault::entries`].
+    pub fn notes(&self) -> Vec<Note> {
+        fn flatten(entry: VaultEntry) -> Vec<Note> {
+            match entry {
+                VaultEntry::File(note) => vec![note],
+                VaultEntry::Directory { entries, .. } => {
+                    entries.into_iter().flat_map(flatten).collect()
+                }
+            }
+        }
+        self.entries().into_iter().flat_map(flatten).collect()
+    }
+
+    /// Resolves a wiki link target (`[[name]]`) to a note by base name, matched
+    /// case-insensitively. A target carrying a subpath (`folder/name`) matches on
+    /// its final component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tempfile::tempdir;
+    /// use basalt_core::obsidian::{self, Vault, Error};
+    ///
+    /// let tmp_dir = tempdir()?;
+    /// let vault = Vault { path: tmp_dir.path().to_path_buf(), ..Default::default() };
+    /// let note = obsidian::vault::create_note(&vault.path, "Meeting Notes")?;
+    ///
+    /// assert_eq!(vault.find_note("Meeting Notes").as_ref(), Some(&note));
+    /// assert_eq!(vault.find_note("meeting notes").as_ref(), Some(&note));
+    /// assert_eq!(vault.find_note("notes/Meeting Notes").as_ref(), Some(&note));
+    /// assert_eq!(vault.find_note("Missing"), None);
+    /// # Ok::<(), Error>(())
+    /// ```
+    pub fn find_note(&self, name: &str) -> Option<Note> {
+        let name = name.rsplit('/').next().unwrap_or(name).to_lowercase();
+        self.notes()
+            .into_iter()
+            .find(|note| note.name().to_lowercase() == name)
     }
 }
 

--- a/basalt/Cargo.toml
+++ b/basalt/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.91.0"
 default-run = "basalt"
 
 [dependencies]
-basalt-core = { path = "../basalt-core", version = "0.9.0" }
+basalt-core = { path = "../basalt-core", version = "0.10.0" }
 clap = { version = "4.6.1", features = ["derive", "string"] }
 ratatui = { version = "0.30.0" }
 crossterm = "0.29.0"

--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -61,6 +61,8 @@
 # note_editor_toggle_outline: toggles outline pane
 # note_editor_switch_pane_next: switches focus to next pane
 # note_editor_switch_pane_previous: switches focus to previous pane
+# note_editor_follow_link: follows the link under the cursor: travels to a
+#   wikilink's note (creating it if missing) or opens a URL in the browser
 
 # Experimental note editor commands:
 # note_editor_experimental_set_edit_view: changes to edit view
@@ -211,6 +213,8 @@ key_bindings = [
  { key = "ctrl+o", command = "note_editor_toggle_outline" },
  { key = "ctrl+shift+up", command = "note_editor_scroll_to_top" },
  { key = "ctrl+shift+down", command = "note_editor_scroll_to_bottom" },
+ { key = "enter", command = "note_editor_follow_link" },
+ { key = "gd", command = "note_editor_follow_link" },
 
  # Experimental editor 
  { key = "i", command = "note_editor_experimental_set_edit_view" },

--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -66,6 +66,8 @@
 # note_editor_toggle_outline: toggles outline pane
 # note_editor_switch_pane_next: switches focus to next pane
 # note_editor_switch_pane_previous: switches focus to previous pane
+# note_editor_follow_link: follows the link under the cursor: travels to a
+#   wikilink's note (creating it if missing) or opens a URL in the browser
 
 # Experimental note editor commands:
 # note_editor_experimental_set_edit_view: changes to edit view
@@ -240,6 +242,8 @@ key_bindings = [
  { key = "ctrl+o", command = "note_editor_toggle_outline" },
  { key = "ctrl+shift+up", command = "note_editor_scroll_to_top" },
  { key = "ctrl+shift+down", command = "note_editor_scroll_to_bottom" },
+ { key = "enter", command = "note_editor_follow_link" },
+ { key = "gd", command = "note_editor_follow_link" },
 
  # Experimental editor 
  { key = "i", command = "note_editor_experimental_set_edit_view" },

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -1,4 +1,6 @@
-use basalt_core::obsidian::{self, create_untitled_dir, create_untitled_note, Note, Vault};
+use basalt_core::obsidian::{
+    self, create_note, create_untitled_dir, create_untitled_note, Note, Vault,
+};
 use ratatui::{
     buffer::Buffer,
     crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
@@ -117,6 +119,7 @@ pub enum Message<'a> {
     Quit,
     Exec(String),
     Spawn(String),
+    FollowLink(note_editor::LinkTarget),
     CopyToClipboard(String),
     Resize(Size),
     SetActivePane(ActivePane),
@@ -796,6 +799,44 @@ impl<'a> App<'a> {
                     .unwrap_or_default();
 
                 return command::spawn_command(command, &state.vault.name, note_name, &note_path);
+            }
+
+            Message::FollowLink(note_editor::LinkTarget::Url(url)) => {
+                return command::open_url(&url);
+            }
+            Message::FollowLink(note_editor::LinkTarget::Wikilink(name)) => {
+                if let Some(note) = state.vault.find_note(&name) {
+                    state.explorer.reveal_path(note.path());
+                    return Some(Message::SelectNote(note.into()));
+                }
+                let directory = state
+                    .tabs
+                    .active_note()
+                    .and_then(|note| note.path().parent())
+                    .unwrap_or(&state.vault.path);
+                match create_note(directory, &name) {
+                    Ok(note) => {
+                        info!(path = %note.path().display(), "created note from wiki link");
+                        return Some(Message::Batch(vec![
+                            Message::RefreshVault {
+                                rename: None,
+                                select: Some(note.path().to_path_buf()),
+                            },
+                            Message::SelectNote(note.into()),
+                            Message::Toast(toast::Message::Create(toast::Toast::success(
+                                "Note created",
+                                Duration::from_secs(2),
+                            ))),
+                        ]));
+                    }
+                    Err(error) => {
+                        error!(?error, name, "failed to create note from wiki link");
+                        return Some(Message::Toast(toast::Message::Create(toast::Toast::error(
+                            "Failed to create note",
+                            Duration::from_secs(2),
+                        ))));
+                    }
+                }
             }
 
             Message::CopyToClipboard(text) => {

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -1,4 +1,6 @@
-use basalt_core::obsidian::{self, create_untitled_dir, create_untitled_note, Note, Vault};
+use basalt_core::obsidian::{
+    self, create_note, create_untitled_dir, create_untitled_note, Note, Vault,
+};
 use ratatui::{
     buffer::Buffer,
     crossterm::{
@@ -131,6 +133,7 @@ pub enum Message<'a> {
     Quit,
     Exec(String),
     Spawn(String),
+    FollowLink(note_editor::LinkTarget),
     CopyToClipboard(String),
     Resize(Size),
     SetActivePane(ActivePane),
@@ -871,6 +874,44 @@ impl<'a> App<'a> {
                     .unwrap_or_default();
 
                 return command::spawn_command(command, &state.vault.name, note_name, &note_path);
+            }
+
+            Message::FollowLink(note_editor::LinkTarget::Url(url)) => {
+                return command::open_url(&url);
+            }
+            Message::FollowLink(note_editor::LinkTarget::Wikilink(name)) => {
+                if let Some(note) = state.vault.find_note(&name) {
+                    state.explorer.reveal_path(note.path());
+                    return Some(Message::SelectNote(note.into()));
+                }
+                let directory = state
+                    .tabs
+                    .active_note()
+                    .and_then(|note| note.path().parent())
+                    .unwrap_or(&state.vault.path);
+                match create_note(directory, &name) {
+                    Ok(note) => {
+                        info!(path = %note.path().display(), "created note from wiki link");
+                        return Some(Message::Batch(vec![
+                            Message::RefreshVault {
+                                rename: None,
+                                select: Some(note.path().to_path_buf()),
+                            },
+                            Message::SelectNote(note.into()),
+                            Message::Toast(toast::Message::Create(toast::Toast::success(
+                                "Note created",
+                                Duration::from_secs(2),
+                            ))),
+                        ]));
+                    }
+                    Err(error) => {
+                        error!(?error, name, "failed to create note from wiki link");
+                        return Some(Message::Toast(toast::Message::Create(toast::Toast::error(
+                            "Failed to create note",
+                            Duration::from_secs(2),
+                        ))));
+                    }
+                }
             }
 
             Message::CopyToClipboard(text) => {

--- a/basalt/src/command.rs
+++ b/basalt/src/command.rs
@@ -6,7 +6,7 @@ use ratatui::{
     DefaultTerminal,
 };
 use serde::{Deserialize, Deserializer};
-use std::{io::stdout, process};
+use std::{io::stdout, process, time::Duration};
 use tracing::error;
 
 use crate::{
@@ -14,7 +14,7 @@ use crate::{
     debug_log, explorer, help_modal, input, note_editor,
     note_editor::state::Operator,
     note_editor::Direction,
-    outline, splash_modal, vault_selector_modal,
+    outline, splash_modal, toast, vault_selector_modal,
 };
 
 trait ReplaceVar {
@@ -113,6 +113,7 @@ pub(crate) enum Command {
     NoteEditorParagraphForward,
     NoteEditorParagraphBackward,
     NoteEditorMatchingPair,
+    NoteEditorFollowLink,
     NoteEditorCursorDocStart,
     NoteEditorCursorDocEnd,
     NoteEditorFindForward,
@@ -273,6 +274,7 @@ fn str_to_command(s: &str) -> Option<Command> {
         "note_editor_paragraph_forward" => Some(Command::NoteEditorParagraphForward),
         "note_editor_paragraph_backward" => Some(Command::NoteEditorParagraphBackward),
         "note_editor_matching_pair" => Some(Command::NoteEditorMatchingPair),
+        "note_editor_follow_link" => Some(Command::NoteEditorFollowLink),
         "note_editor_cursor_doc_start" => Some(Command::NoteEditorCursorDocStart),
         "note_editor_cursor_doc_end" => Some(Command::NoteEditorCursorDocEnd),
         "note_editor_find_forward" => Some(Command::NoteEditorFindForward),
@@ -537,6 +539,7 @@ impl From<Command> for Message<'_> {
             Command::NoteEditorMatchingPair => {
                 Message::NoteEditor(note_editor::Message::MatchingPair)
             }
+            Command::NoteEditorFollowLink => Message::NoteEditor(note_editor::Message::FollowLink),
             Command::NoteEditorCursorDocStart => {
                 Message::NoteEditor(note_editor::Message::CursorDocStart)
             }
@@ -680,4 +683,26 @@ pub fn spawn_command<'a>(
             None
         },
     )
+}
+
+/// Opens a URL with the platform's default handler. Returns an error toast when
+/// the opener cannot be launched.
+pub fn open_url<'a>(url: &str) -> Option<Message<'a>> {
+    #[cfg(target_os = "macos")]
+    let (opener, args): (&str, &[&str]) = ("open", &[]);
+    #[cfg(target_os = "linux")]
+    let (opener, args): (&str, &[&str]) = ("xdg-open", &[]);
+    #[cfg(target_os = "windows")]
+    let (opener, args): (&str, &[&str]) = ("cmd", &["/C", "start", ""]);
+
+    match process::Command::new(opener).args(args).arg(url).spawn() {
+        Ok(_) => None,
+        Err(error) => {
+            error!(?error, url, "failed to open url");
+            Some(Message::Toast(toast::Message::Create(toast::Toast::error(
+                "Failed to open link",
+                Duration::from_secs(2),
+            ))))
+        }
+    }
 }

--- a/basalt/src/command.rs
+++ b/basalt/src/command.rs
@@ -6,7 +6,7 @@ use ratatui::{
     DefaultTerminal,
 };
 use serde::{Deserialize, Deserializer};
-use std::{io::stdout, process};
+use std::{io::stdout, process, time::Duration};
 use tracing::error;
 
 use crate::{
@@ -14,7 +14,7 @@ use crate::{
     debug_log, explorer, help_modal, input, note_editor,
     note_editor::state::Operator,
     note_editor::Direction,
-    outline, splash_modal, theme_selector_modal, vault_selector_modal,
+    outline, splash_modal, theme_selector_modal, toast, vault_selector_modal,
 };
 
 trait ReplaceVar {
@@ -115,6 +115,7 @@ pub(crate) enum Command {
     NoteEditorParagraphForward,
     NoteEditorParagraphBackward,
     NoteEditorMatchingPair,
+    NoteEditorFollowLink,
     NoteEditorCursorDocStart,
     NoteEditorCursorDocEnd,
     NoteEditorFindForward,
@@ -283,6 +284,7 @@ fn str_to_command(s: &str) -> Option<Command> {
         "note_editor_paragraph_forward" => Some(Command::NoteEditorParagraphForward),
         "note_editor_paragraph_backward" => Some(Command::NoteEditorParagraphBackward),
         "note_editor_matching_pair" => Some(Command::NoteEditorMatchingPair),
+        "note_editor_follow_link" => Some(Command::NoteEditorFollowLink),
         "note_editor_cursor_doc_start" => Some(Command::NoteEditorCursorDocStart),
         "note_editor_cursor_doc_end" => Some(Command::NoteEditorCursorDocEnd),
         "note_editor_find_forward" => Some(Command::NoteEditorFindForward),
@@ -559,6 +561,7 @@ impl From<Command> for Message<'_> {
             Command::NoteEditorMatchingPair => {
                 Message::NoteEditor(note_editor::Message::MatchingPair)
             }
+            Command::NoteEditorFollowLink => Message::NoteEditor(note_editor::Message::FollowLink),
             Command::NoteEditorCursorDocStart => {
                 Message::NoteEditor(note_editor::Message::CursorDocStart)
             }
@@ -717,4 +720,29 @@ pub fn spawn_command<'a>(
             None
         },
     )
+}
+
+/// Opens a URL with the platform's default handler. Returns an error toast when
+/// the opener cannot be launched.
+pub fn open_url<'a>(url: &str) -> Option<Message<'a>> {
+    let (opener, args): (&str, &[&str]) = {
+        if cfg!(target_os = "macos") {
+            ("open", &[])
+        } else if cfg!(target_os = "windows") {
+            ("cmd", &["/C", "start", ""])
+        } else {
+            ("xdg-open", &[])
+        }
+    };
+
+    match process::Command::new(opener).args(args).arg(url).spawn() {
+        Ok(_) => None,
+        Err(error) => {
+            error!(?error, url, "failed to open url");
+            Some(Message::Toast(toast::Message::Create(toast::Toast::error(
+                "Failed to open link",
+                Duration::from_secs(2),
+            ))))
+        }
+    }
 }

--- a/basalt/src/note_editor/mod.rs
+++ b/basalt/src/note_editor/mod.rs
@@ -14,6 +14,8 @@ mod virtual_document;
 // `Direction` is part of the public `Message::FindChar` API, so re-export it
 // for callers (command dispatch) that construct find messages.
 pub use motion::Direction;
+// `LinkTarget` is carried by `AppMessage::FollowLink`, resolved in `app.rs`.
+pub use motion::LinkTarget;
 
 use std::time::Duration;
 
@@ -66,6 +68,7 @@ pub enum Message {
     ParagraphForward,
     ParagraphBackward,
     MatchingPair,
+    FollowLink,
     CursorDocStart,
     CursorDocEnd,
     FindChar {
@@ -319,6 +322,9 @@ pub fn update<'a>(
             state.cursor_right(count);
         }
         Message::JumpToBlock(idx) => state.cursor_jump(idx),
+        Message::FollowLink => {
+            return motion::link_at(&state.content, offset(state)).map(AppMessage::FollowLink);
+        }
         Message::CursorUp => {
             let count = state.take_count().unwrap_or(1);
             if state.pending_operator().is_some() {

--- a/basalt/src/note_editor/mod.rs
+++ b/basalt/src/note_editor/mod.rs
@@ -14,6 +14,8 @@ mod virtual_document;
 // `Direction` is part of the public `Message::FindChar` API, so re-export it
 // for callers (command dispatch) that construct find messages.
 pub use motion::Direction;
+// `LinkTarget` is carried by `AppMessage::FollowLink`, resolved in `app.rs`.
+pub use motion::LinkTarget;
 
 use std::time::Duration;
 
@@ -68,6 +70,7 @@ pub enum Message {
     ParagraphForward,
     ParagraphBackward,
     MatchingPair,
+    FollowLink,
     CursorDocStart,
     CursorDocEnd,
     FindChar {
@@ -321,6 +324,9 @@ pub fn update<'a>(
             state.cursor_right(count);
         }
         Message::JumpToBlock(idx) => state.cursor_jump(idx),
+        Message::FollowLink => {
+            return motion::link_at(&state.content, offset(state)).map(AppMessage::FollowLink);
+        }
         Message::CursorUp => {
             let count = state.take_count().unwrap_or(1);
             if state.pending_operator().is_some() {

--- a/basalt/src/note_editor/motion.rs
+++ b/basalt/src/note_editor/motion.rs
@@ -492,6 +492,76 @@ pub fn goto_line(content: &str, line: usize) -> usize {
     first_nonblank(content, start)
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LinkTarget {
+    /// `[[note]]`, `[[note#heading]]` or `[[note|alias]]`, resolved to the note name.
+    Wikilink(String),
+    /// A bare URL or the target of a markdown link.
+    Url(String),
+}
+
+pub fn link_at(content: &str, offset: usize) -> Option<LinkTarget> {
+    let offset = offset.min(content.len());
+    if let Some(name) = wikilink_at(content, offset) {
+        return Some(LinkTarget::Wikilink(name.to_string()));
+    }
+    let url = markdown_link_at(content, offset).or_else(|| bare_url_at(content, offset))?;
+    Some(LinkTarget::Url(url.to_string()))
+}
+
+fn wikilink_at(content: &str, offset: usize) -> Option<&str> {
+    let open = last_match(content, "[[", offset)?;
+    let close = content[open + 2..].find("]]")? + open + 2;
+    if !(open..close + 2).contains(&offset) {
+        return None;
+    }
+
+    content[open + 2..close]
+        .split(['#', '|'])
+        .next()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+}
+
+fn markdown_link_at(content: &str, offset: usize) -> Option<&str> {
+    content.match_indices("](").find_map(|(bracket, _)| {
+        let open = content[..bracket].rfind('[')?;
+        let url = bracket + 2;
+        let close = content[url..].find(')')? + url;
+        (open..=close)
+            .contains(&offset)
+            .then_some(&content[url..close])
+    })
+}
+
+fn bare_url_at(content: &str, offset: usize) -> Option<&str> {
+    let start = content[..offset]
+        .rfind(char::is_whitespace)
+        .map_or(0, |index| index + 1);
+    let end = content[offset..]
+        .find(char::is_whitespace)
+        .map_or(content.len(), |index| offset + index);
+
+    let url = content[start..end]
+        .trim_start_matches(['(', '[', '<'])
+        .trim_end_matches([')', ']', '>', '.', ',', ';', '!', '?']);
+
+    let (scheme, rest) = url.split_once("://")?;
+    let valid_scheme = !scheme.is_empty()
+        && scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "+-.".contains(c));
+    (valid_scheme && !rest.is_empty()).then_some(url)
+}
+
+fn last_match(content: &str, needle: &str, offset: usize) -> Option<usize> {
+    content
+        .match_indices(needle)
+        .map(|(index, _)| index)
+        .take_while(|&index| index <= offset)
+        .last()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -683,5 +753,64 @@ mod tests {
         assert_eq!(line_down(text, 0, 9), 8); // clamps at the last line
         assert_eq!(line_up(text, 8, 1), 4); // back to 'two'
         assert_eq!(line_up(text, 8, 9), 0); // clamps at the first line
+    }
+
+    fn wikilink(text: &str, needle: &str) -> Option<LinkTarget> {
+        link_at(text, text.find(needle).unwrap())
+    }
+
+    #[test]
+    fn link_at_wikilink_strips_alias_and_heading() {
+        assert_eq!(
+            wikilink("see [[Note A]] now", "Note"),
+            Some(LinkTarget::Wikilink("Note A".into()))
+        );
+        assert_eq!(
+            wikilink("[[Note A|alias]]", "alias"),
+            Some(LinkTarget::Wikilink("Note A".into()))
+        );
+        assert_eq!(
+            wikilink("[[Note A#Heading]]", "Heading"),
+            Some(LinkTarget::Wikilink("Note A".into()))
+        );
+    }
+
+    #[test]
+    fn link_at_wikilink_edges_and_outside() {
+        let text = "x [[Note A]] y";
+        assert_eq!(link_at(text, 2), wikilink(text, "Note")); // on first '['
+        assert_eq!(link_at(text, 10), wikilink(text, "Note")); // on closing ']'
+        assert_eq!(link_at(text, 0), None); // before the link
+        assert_eq!(link_at(text, 13), None); // after the link
+    }
+
+    #[test]
+    fn link_at_urls() {
+        assert_eq!(
+            wikilink("visit https://example.com today", "https"),
+            Some(LinkTarget::Url("https://example.com".into()))
+        );
+        assert_eq!(
+            wikilink("wrapped (https://example.com).", "https"),
+            Some(LinkTarget::Url("https://example.com".into()))
+        );
+    }
+
+    #[test]
+    fn link_at_markdown_link_from_label_or_url() {
+        let text = "a [my label](https://x.com) b";
+        assert_eq!(
+            link_at(text, text.find("label").unwrap()),
+            Some(LinkTarget::Url("https://x.com".into()))
+        );
+        assert_eq!(
+            link_at(text, text.find("x.com").unwrap()),
+            Some(LinkTarget::Url("https://x.com".into()))
+        );
+    }
+
+    #[test]
+    fn link_at_plain_text_is_none() {
+        assert_eq!(link_at("just some text", 5), None);
     }
 }

--- a/basalt/src/note_editor/motion.rs
+++ b/basalt/src/note_editor/motion.rs
@@ -492,6 +492,86 @@ pub fn goto_line(content: &str, line: usize) -> usize {
     first_nonblank(content, start)
 }
 
+/// A link the cursor is sitting on, resolvable by the `gx` motion.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LinkTarget {
+    /// `[[note]]`, `[[note#heading]]` or `[[note|alias]]`, resolved to the note name.
+    Wikilink(String),
+    /// A bare URL or the target of a `[label](url)` markdown link.
+    Url(String),
+}
+
+/// Classifies whatever link sits under `offset`: a wiki link first, then a
+/// markdown or bare URL. Returns `None` when the cursor is not on a link.
+pub fn link_at(content: &str, offset: usize) -> Option<LinkTarget> {
+    let offset = offset.min(content.len());
+    if let Some(name) = wikilink_at(content, offset) {
+        return Some(LinkTarget::Wikilink(name));
+    }
+    let url = markdown_link_at(content, offset).or_else(|| bare_url_at(content, offset))?;
+    Some(LinkTarget::Url(url.to_string()))
+}
+
+/// The note name of the `[[...]]` enclosing `offset`, with `#heading`/`|alias`
+/// stripped. `None` when the cursor is outside any wiki link span.
+fn wikilink_at(content: &str, offset: usize) -> Option<String> {
+    let open = last_match(content, "[[", offset)?;
+    let close = content[open + 2..].find("]]")? + open + 2;
+    if !(open..close + 2).contains(&offset) {
+        return None;
+    }
+
+    content[open + 2..close]
+        .split(['#', '|'])
+        .next()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(String::from)
+}
+
+/// The URL of a `[label](url)` markdown link enclosing `offset`.
+fn markdown_link_at(content: &str, offset: usize) -> Option<&str> {
+    content.match_indices("](").find_map(|(bracket, _)| {
+        let open = content[..bracket].rfind('[')?;
+        let url = bracket + 2;
+        let close = content[url..].find(')')? + url;
+        (open..=close)
+            .contains(&offset)
+            .then_some(&content[url..close])
+    })
+}
+
+/// A bare URL in the whitespace-delimited token under `offset`, trimmed of
+/// wrapping brackets and trailing sentence punctuation.
+fn bare_url_at(content: &str, offset: usize) -> Option<&str> {
+    let start = content[..offset]
+        .rfind(char::is_whitespace)
+        .map_or(0, |index| index + 1);
+    let end = content[offset..]
+        .find(char::is_whitespace)
+        .map_or(content.len(), |index| offset + index);
+
+    let url = content[start..end]
+        .trim_start_matches(['(', '[', '<'])
+        .trim_end_matches([')', ']', '>', '.', ',', ';', '!', '?']);
+
+    let (scheme, rest) = url.split_once("://")?;
+    let valid_scheme = !scheme.is_empty()
+        && scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "+-.".contains(c));
+    (valid_scheme && !rest.is_empty()).then_some(url)
+}
+
+/// The byte offset of the last occurrence of `needle` starting at or before `offset`.
+fn last_match(content: &str, needle: &str, offset: usize) -> Option<usize> {
+    content
+        .match_indices(needle)
+        .map(|(index, _)| index)
+        .take_while(|&index| index <= offset)
+        .last()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -683,5 +763,64 @@ mod tests {
         assert_eq!(line_down(text, 0, 9), 8); // clamps at the last line
         assert_eq!(line_up(text, 8, 1), 4); // back to 'two'
         assert_eq!(line_up(text, 8, 9), 0); // clamps at the first line
+    }
+
+    fn wikilink(text: &str, needle: &str) -> Option<LinkTarget> {
+        link_at(text, text.find(needle).unwrap())
+    }
+
+    #[test]
+    fn link_at_wikilink_strips_alias_and_heading() {
+        assert_eq!(
+            wikilink("see [[Note A]] now", "Note"),
+            Some(LinkTarget::Wikilink("Note A".into()))
+        );
+        assert_eq!(
+            wikilink("[[Note A|alias]]", "alias"),
+            Some(LinkTarget::Wikilink("Note A".into()))
+        );
+        assert_eq!(
+            wikilink("[[Note A#Heading]]", "Heading"),
+            Some(LinkTarget::Wikilink("Note A".into()))
+        );
+    }
+
+    #[test]
+    fn link_at_wikilink_edges_and_outside() {
+        let text = "x [[Note A]] y";
+        assert_eq!(link_at(text, 2), wikilink(text, "Note")); // on first '['
+        assert_eq!(link_at(text, 10), wikilink(text, "Note")); // on closing ']'
+        assert_eq!(link_at(text, 0), None); // before the link
+        assert_eq!(link_at(text, 13), None); // after the link
+    }
+
+    #[test]
+    fn link_at_urls() {
+        assert_eq!(
+            wikilink("visit https://example.com today", "https"),
+            Some(LinkTarget::Url("https://example.com".into()))
+        );
+        assert_eq!(
+            wikilink("wrapped (https://example.com).", "https"),
+            Some(LinkTarget::Url("https://example.com".into()))
+        );
+    }
+
+    #[test]
+    fn link_at_markdown_link_from_label_or_url() {
+        let text = "a [my label](https://x.com) b";
+        assert_eq!(
+            link_at(text, text.find("label").unwrap()),
+            Some(LinkTarget::Url("https://x.com".into()))
+        );
+        assert_eq!(
+            link_at(text, text.find("x.com").unwrap()),
+            Some(LinkTarget::Url("https://x.com".into()))
+        );
+    }
+
+    #[test]
+    fn link_at_plain_text_is_none() {
+        assert_eq!(link_at("just some text", 5), None);
     }
 }

--- a/basalt/vim.toml
+++ b/basalt/vim.toml
@@ -40,6 +40,7 @@ key_bindings = [
   { key = "{", command = "note_editor_paragraph_backward" },
   { key = "}", command = "note_editor_paragraph_forward" },
   { key = "%", command = "note_editor_matching_pair" },
+  { key = "gx", command = "note_editor_follow_link" },
   { key = "f", command = "note_editor_find_forward" },
   { key = "F", command = "note_editor_find_backward" },
   { key = "t", command = "note_editor_till_forward" },

--- a/basalt/vim.toml
+++ b/basalt/vim.toml
@@ -42,6 +42,7 @@ key_bindings = [
   { key = "{", command = "note_editor_paragraph_backward" },
   { key = "}", command = "note_editor_paragraph_forward" },
   { key = "%", command = "note_editor_matching_pair" },
+  { key = "gx", command = "note_editor_follow_link" },
   { key = "f", command = "note_editor_find_forward" },
   { key = "F", command = "note_editor_find_backward" },
   { key = "t", command = "note_editor_till_forward" },


### PR DESCRIPTION
Adds a note editor action that follows whatever link sits under the cursor, in the spirit of vim's `gx`.

## Behavior

- **Wikilink** (`[[Note]]`, `[[Note|alias]]`, `[[Note#heading]]`): travels to that note. If the note does not exist it is created in the current note's folder and opened, matching Obsidian. The explorer selection follows the opened note.
- **URL** (bare `https://...` or the target of a `[label](url)` markdown link): opens in the platform browser via `open` / `xdg-open` / `cmd start`.
- Cursor on plain text is a silent no-op.

## Keys

- `gx` in the vim config (`vim.toml`).
- `enter` and `gd` in the default config (`config.toml`).