### PR TITLE
Keep the cursor line from panning when wrapped text reaches the edge

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.12.7](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.12.7) (Unreleased)
+## [0.12.7](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.12.7) (Aug, 14 2026)
 
 ### Added
 
@@ -183,6 +183,16 @@
 > are regenerated in each theme.
 
 ### Fixed
+
+- [59120fd](https://github.com/erikjuhani/basalt/commit/59120fd4098375746a83b473c2b6bc62b49aa4f1) Keep the cursor line from panning when wrapped text reaches the edge by @erikjuhani
+
+> While editing, typing a word that filled the line to the viewport width
+> panned the viewport right by one column, hiding the first column of every
+> line. The pan stuck even after the word wrapped to the next visual line.
+>
+> Wrapped text never exceeds the viewport width, so it needs no horizontal
+> pan. Reset the pan to zero for lines that fit, and keep panning only for
+> lines that truly overflow, such as code blocks and long unbroken words.
 
 - [1aa72d0](https://github.com/erikjuhani/basalt/commit/1aa72d00abe7e0bdb00aa883921422aae12dbb1d) Highlight prettified list markers in visual selection by @erikjuhani
 

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -503,7 +503,21 @@ impl<'a> NoteEditorState<'a> {
             0
         };
 
-        let horizontal = if cursor_column < self.viewport.left() as i32 {
+        let line_width = self
+            .virtual_document
+            .lines()
+            .get(self.cursor.virtual_row())
+            .map(|line| {
+                line.virtual_spans()
+                    .iter()
+                    .map(|span| span.width())
+                    .sum::<usize>()
+            })
+            .unwrap_or(0);
+
+        let horizontal = if line_width <= self.viewport.width as usize {
+            -(self.viewport.left() as i32)
+        } else if cursor_column < self.viewport.left() as i32 {
             cursor_column - self.viewport.left() as i32
         } else if cursor_column >= self.viewport.right() as i32 {
             cursor_column - self.viewport.right() as i32 + 1
@@ -1884,6 +1898,30 @@ mod tests {
         state.resize_viewport(Size::new(40, 10));
         state.set_view(View::Edit(EditMode::Source));
         state
+    }
+
+    #[test]
+    fn test_typing_wrapping_paragraph_never_pans_horizontally() {
+        let mut state =
+            NoteEditorState::new("hello\n", "test", Path::new("test.md"), &Symbols::unicode());
+        state.resize_viewport(Size::new(12, 20));
+        state.set_view(View::Edit(EditMode::Source));
+        state.cursor_right(100);
+
+        for c in " world foobar".chars() {
+            state.insert_char(c);
+            assert_eq!(
+                state.viewport().left(),
+                0,
+                "wrapped text must not pan; left stayed non-zero after typing {c:?}",
+            );
+        }
+
+        assert!(
+            state.cursor.virtual_row() > 0,
+            "the word should have wrapped"
+        );
+        assert_cursor_visible(&state, "after the word wrapped");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a flicker while writing in the note editor. When you typed a word that
filled the line to the viewport width, the cursor column reached the right
edge and the viewport panned right by one column. That pushed the first
column of every line off-screen. The pan stuck even after the word wrapped to
the next visual line, so the first character stayed hidden.

Wrapped text never exceeds the viewport width, so it needs no horizontal pan.
`ensure_cursor_visible` now measures the cursor's line width. If the line fits
the viewport, it resets the pan to zero. A line that truly overflows (a code
block or a long unbroken word) still pans to follow the cursor.

Added a regression test that types a wrapping paragraph and asserts the
viewport never pans.

Note: a separate read-vs-edit vertical spacing difference (a heading or extra
blank lines shift when you start editing) is intentionally left out of scope.
It needs a design decision on which view is authoritative.