### PR TITLE
Point site base_url at custom domain

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://erikjuhani.github.io/basalt"
+base_url = "https://basalt.page"
 title = "basalt"
 description = "TUI to manage Obsidian vaults and notes from the terminal."
 default_language = "en"


### PR DESCRIPTION
## Problem

The site styling breaks on the live site. The console shows a mixed-content block on `http://basalt.page/main.css`, even though nothing in the source uses `http://`.

The cause is a stale `base_url`. Zola stamps `base_url` into every asset link, and `site/config.toml` still pointed at the old GitHub Pages project URL:

```toml
base_url = "https://erikjuhani.github.io/basalt"
```

The live page loaded `https://erikjuhani.github.io/basalt/main.css`. GitHub redirected that old URL to the custom domain, and the redirect landed on `http://basalt.page/main.css`. The `https` page then blocked it as mixed content.

## Fix

Set `base_url` to the custom domain:

```toml
base_url = "https://basalt.page"
```

Zola now writes `https://basalt.page/main.css`, the redirect is gone, and the styling loads.