### PR TITLE
Speed up note rendering

### DIFF
--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -418,7 +418,7 @@ mod tests {
             .into_iter()
             .flat_map(|node| {
                 render_node(
-                    content.to_string(),
+                    content,
                     &node,
                     80,
                     0,
@@ -664,7 +664,7 @@ mod tests {
             .into_iter()
             .flat_map(|node| {
                 render_node(
-                    content.to_string(),
+                    content,
                     &node,
                     80,
                     0,

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -23,11 +23,12 @@ fn render_highlight(
     buf: &mut Buffer,
     inner_area: Rect,
     viewport: &Viewport,
-    lines: &[VirtualLine],
-    meta_len: usize,
+    meta: &[VirtualLine],
+    doc: &[VirtualLine],
     range: &Range<usize>,
     style: Style,
 ) {
+    let meta_len = meta.len();
     let viewport_top = viewport.top() as usize;
     let horizontal_scroll = viewport.left();
 
@@ -39,8 +40,8 @@ fn render_highlight(
         }
     };
 
-    lines
-        .iter()
+    meta.iter()
+        .chain(doc.iter())
         .enumerate()
         .skip(viewport_top)
         .take(inner_area.height as usize)
@@ -132,20 +133,21 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
 
         state.update_layout();
 
-        let mut lines = state.virtual_document.meta().to_vec();
-        lines.extend(state.virtual_document.lines().to_vec());
+        let meta = state.virtual_document.meta();
+        let doc = state.virtual_document.lines();
+        let meta_lines_count = meta.len();
+        let rendered_lines_count = doc.len();
+        let total_lines = meta_lines_count + rendered_lines_count;
 
-        let visible_lines = lines
+        // Clone only the on-screen window, never the whole document.
+        let visible_lines = meta
             .iter()
+            .chain(doc.iter())
             .skip(state.viewport().top() as usize)
             .take(state.viewport().bottom() as usize)
-            // Cheaper to clone the subset of the lines
             .cloned()
             .map(|visual_line| visual_line.into())
             .collect::<Vec<Line>>();
-
-        let rendered_lines_count = state.virtual_document.lines().len();
-        let meta_lines_count = state.virtual_document.meta().len();
 
         Paragraph::new(visible_lines)
             .scroll((0, state.viewport().left()))
@@ -157,8 +159,8 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
                 buf,
                 inner_area,
                 state.viewport(),
-                &lines,
-                meta_lines_count,
+                meta,
+                doc,
                 &range,
                 SELECTION_STYLE,
             );
@@ -169,8 +171,8 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
                 buf,
                 inner_area,
                 state.viewport(),
-                &lines,
-                meta_lines_count,
+                meta,
+                doc,
                 &range,
                 YANK_FLASH_STYLE,
             );
@@ -187,7 +189,7 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
                 .render(state.viewport().area(), buf, &mut state.cursor);
         }
 
-        if !area.is_empty() && lines.len() as u16 > inner_area.bottom() {
+        if !area.is_empty() && total_lines as u16 > inner_area.bottom() {
             let mut scroll_state =
                 ScrollbarState::new(rendered_lines_count).position(state.cursor.virtual_row());
 

--- a/basalt/src/note_editor/render.rs
+++ b/basalt/src/note_editor/render.rs
@@ -827,7 +827,7 @@ pub fn list<'a>(
 
                     lines.extend(
                         render_node(
-                            content.to_string(),
+                            content,
                             node,
                             max_width,
                             horizontal_offset,
@@ -915,7 +915,7 @@ pub fn task<'a>(
 
             lines.extend(rest.iter().flat_map(|node| {
                 render_node(
-                    content.to_string(),
+                    content,
                     node,
                     max_width,
                     horizontal_offset,
@@ -987,7 +987,7 @@ pub fn item<'a>(
 
             lines.extend(rest.iter().flat_map(|node| {
                 render_node(
-                    content.to_string(),
+                    content,
                     node,
                     max_width,
                     horizontal_offset,
@@ -1156,7 +1156,7 @@ pub fn block_quote<'a>(
             for (i, node) in nodes.iter().enumerate() {
                 lines.extend(
                     render_node(
-                        content.to_string(),
+                        content,
                         node,
                         max_width,
                         horizontal_offset,
@@ -1633,7 +1633,7 @@ fn table_border<'a>(text: &str) -> Span<'a> {
 // FIXME: Use options struct or similar
 #[allow(clippy::too_many_arguments)]
 pub fn render_node<'a>(
-    content: String,
+    content: &str,
     node: &ast::Node,
     max_width: usize,
     horizontal_offset: usize,
@@ -1651,7 +1651,7 @@ pub fn render_node<'a>(
             source_range,
         } => heading(
             *level,
-            &content,
+            content,
             prefix,
             text,
             source_range,
@@ -1662,7 +1662,7 @@ pub fn render_node<'a>(
             theme,
         ),
         Paragraph { text, source_range } => paragraph(
-            &content,
+            content,
             prefix,
             text,
             source_range,
@@ -1675,7 +1675,7 @@ pub fn render_node<'a>(
             text,
             source_range,
         } => code_block(
-            &content,
+            content,
             prefix,
             lang,
             text,
@@ -1689,7 +1689,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
         } => list(
-            &content,
+            content,
             prefix,
             nodes,
             source_range,
@@ -1705,7 +1705,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
         } => item(
-            &content,
+            content,
             prefix,
             kind,
             nodes,
@@ -1722,7 +1722,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
         } => task(
-            &content,
+            content,
             prefix,
             kind,
             nodes,
@@ -1740,7 +1740,7 @@ pub fn render_node<'a>(
             nodes,
             source_range,
         } => block_quote(
-            &content,
+            content,
             prefix,
             kind,
             title,
@@ -1758,7 +1758,7 @@ pub fn render_node<'a>(
             rows,
             source_range,
         } => table(
-            &content,
+            content,
             prefix,
             alignments,
             head,

--- a/basalt/src/note_editor/virtual_document.rs
+++ b/basalt/src/note_editor/virtual_document.rs
@@ -1,4 +1,5 @@
 use std::{
+    hash::{DefaultHasher, Hash, Hasher},
     iter,
     str::{CharIndices, Chars},
 };
@@ -189,6 +190,29 @@ impl<'a> VirtualBlock<'a> {
     }
 }
 
+fn hash_str(value: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Fingerprint of every input that shapes a layout, so a frame whose inputs are
+/// unchanged reuses the previous result instead of rebuilding the whole document.
+/// The theme is not part of the key; `set_theme` clears the cache instead.
+#[derive(Clone, Debug, PartialEq)]
+struct LayoutKey {
+    name_hash: u64,
+    content_hash: u64,
+    edit: bool,
+    editing_block: Option<usize>,
+    cursor_offset: usize,
+    ast_len: usize,
+    ast_last_end: usize,
+    width: usize,
+    horizontal_offset: usize,
+    buffer: Option<(u64, SourceRange<usize>, bool)>,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct VirtualDocument<'a> {
     symbols: Symbols,
@@ -197,6 +221,7 @@ pub struct VirtualDocument<'a> {
     blocks: Vec<VirtualBlock<'a>>,
     lines: Vec<VirtualLine<'a>>,
     line_to_block: Vec<usize>,
+    cache_key: Option<LayoutKey>,
 }
 
 impl<'a> VirtualDocument<'a> {
@@ -208,7 +233,10 @@ impl<'a> VirtualDocument<'a> {
     }
 
     pub fn set_theme(&mut self, theme: &Theme) {
-        self.theme = *theme;
+        if self.theme != *theme {
+            self.theme = *theme;
+            self.cache_key = None;
+        }
     }
     pub fn meta(&self) -> &[VirtualLine<'_>] {
         &self.meta
@@ -244,6 +272,32 @@ impl<'a> VirtualDocument<'a> {
         horizontal_offset: usize,
         text_buffer: Option<TextBuffer>,
     ) {
+        let edit = matches!(view, View::Edit(..));
+        let key = LayoutKey {
+            name_hash: hash_str(note_name),
+            content_hash: hash_str(content),
+            edit,
+            editing_block: current_block_idx,
+            // The cursor only reshapes layout while editing (it reveals its own
+            // line raw in the active block); in Read mode it never does.
+            cursor_offset: if edit { cursor_offset } else { 0 },
+            ast_len: ast_nodes.len(),
+            ast_last_end: ast_nodes.last().map_or(0, |node| node.source_range().end),
+            width,
+            horizontal_offset,
+            buffer: text_buffer.as_ref().map(|buffer| {
+                (
+                    hash_str(&buffer.content),
+                    buffer.source_range.clone(),
+                    buffer.modified,
+                )
+            }),
+        };
+        if self.cache_key.as_ref() == Some(&key) {
+            return;
+        }
+        self.cache_key = Some(key);
+
         if !note_name.is_empty() {
             let note_name = match self.symbols.title_font_style {
                 Some(style) => stylize(note_name, style),
@@ -330,7 +384,7 @@ impl<'a> VirtualDocument<'a> {
                         VirtualBlock::new(&lines, range)
                     }
                     None => render_node(
-                        live_content.to_string(),
+                        &live_content,
                         node,
                         width,
                         horizontal_offset,


### PR DESCRIPTION
## Problem

The note editor rebuilt the whole document layout on every frame. `NoteEditor::render` called `update_layout()` with no dirty check, so each keystroke and each 250ms idle tick re-ran the full markdown layout and then cloned the result twice to draw one screen. A large note stayed near 20fps and burned CPU while idle.

Two costs stacked up:

1. `layout()` ran unconditionally every frame, even when nothing changed.
2. `render_node` took `content` by value, so `layout()` handed each block an owned copy of the whole document. That made a single layout O(blocks * content length).

## Changes

- **Memoize the layout.** `VirtualDocument::layout` builds a fingerprint of its inputs (content, edit buffer, view, active block, cursor, width, offsets, name) and returns early when nothing changed. `set_theme` clears the cache, because the theme recolors spans.
- **Borrow content in `render_node`.** The function only slices `content`, so the per-block copies were waste. It now takes `&str`.
- **Clone only the visible window.** The draw path slices the on-screen rows from borrowed data. `render_highlight` reads the meta and document slices directly instead of a combined copy.
