### PR TITLE
Publish rolling nightly builds from main

### DIFF
--- a/.github/scripts/homebrew-formula.sh
+++ b/.github/scripts/homebrew-formula.sh
@@ -29,6 +29,11 @@ class Basalt < Formula
   homepage "https://github.com/erikjuhani/basalt"
   license "GPL-3.0-or-later"
 
+  head do
+    url "https://github.com/erikjuhani/basalt.git", branch: "main"
+    depends_on "rust" => :build
+  end
+
   on_macos do
     on_arm do
       url "${base_url}/basalt-${version}-aarch64-apple-darwin.tar.gz"
@@ -52,11 +57,16 @@ class Basalt < Formula
   end
 
   def install
-    bin.install "basalt"
+    if build.head?
+      system "cargo", "install", *std_cargo_args(path: "basalt")
+    else
+      bin.install "basalt"
+    end
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/basalt --version")
+    expected = build.head? ? "basalt" : version.to_s
+    assert_match expected, shell_output("#{bin}/basalt --version")
   end
 end
 FORMULA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,17 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: Version used in artifact names (defaults to the tag ref)
+        required: false
+        type: string
+        default: ''
+      channel:
+        description: Release channel baked into the binary (e.g. nightly)
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: build-${{ github.ref }}
@@ -80,13 +91,17 @@ jobs:
 
       - name: Build binary
         shell: bash
+        env:
+          BASALT_CHANNEL: ${{ inputs.channel }}
         run: cargo build --locked --release --target "${MATRIX_TARGET}"
 
       - name: Prepare artifact
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           ref_name="${GITHUB_REF_NAME}"
-          version="${ref_name##*/v}"
+          version="${VERSION:-${ref_name##*/v}}"
 
           target="${MATRIX_TARGET}"
           bin_path="target/${target}/release"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,69 @@
+name: Nightly
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      version: nightly
+      channel: nightly
+
+  publish:
+    name: Publish nightly
+    needs: build
+
+    permissions:
+      contents: write # Needed to move the nightly tag and update the prerelease
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ./release-artifacts
+          pattern: artifacts-*
+          merge-multiple: true
+
+      - name: Move the nightly tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          git tag --force nightly
+          git push --force \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            tag nightly
+
+      - name: Publish the nightly prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          describe="$(git describe --tags --match 'basalt/v*' --always)"
+          title="Nightly (${describe})"
+          notes="Automated build from the latest \`main\` (\`${GITHUB_SHA}\`). Unstable, for testing only."
+
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release edit nightly --prerelease --title "${title}" --notes "${notes}"
+            gh release upload nightly ./release-artifacts/* --clobber
+          else
+            gh release create nightly ./release-artifacts/* \
+              --prerelease --title "${title}" --notes "${notes}"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # Agent guidelines for Basalt
 
-This file is for LLMs and coding agents working in this repository. Humans should read [CONTRIBUTING.md](CONTRIBUTING.md).
+This file is for LLMs and coding agents working in this repository.
 
 ## Contribution policy
 
-Basalt is a hand-crafted side project. The maintainer values writing the code himself, so agent-authored contributions are restricted.
+Basalt is _mostly_ hand-crafted side project. The maintainer values writing the code himself, so some agent-authored contributions are restricted.
 
 - **Never open a pull request for a "good first issue".** These are reserved for humans to solve by hand so newcomers can learn the codebase. They are intentionally simple and do not need an LLM. If you were pointed at one, stop and tell your human to program it themselves.
 - **Stay scoped.** Open an issue to discuss feature work before writing it. Don't bundle unrelated changes.

--- a/CLA.md
+++ b/CLA.md
@@ -1,58 +1,33 @@
 # Contributor License Agreement
 
-Thank you for contributing to Basalt. This agreement clarifies the rights you
-grant when you contribute, so the project's licensing stays flexible for
-everyone. It is deliberately light: **you keep ownership of your work.**
+Thank you for contributing to Basalt. This agreement clarifies the rights you grant when you contribute, so the project's licensing stays flexible for everyone. It is deliberately light: **you keep ownership of your work.**
 
-By opening a pull request against this repository, you agree to the terms below
-for that contribution and every contribution you make to the project. No
-separate form, account, or commit sign-off is required.
+By opening a pull request against this repository, you agree to the terms below for that contribution and every contribution you make to the project. No separate form, account, or commit sign-off is required.
 
-In this agreement, "you" is the copyright holder making the contribution, "the
-maintainer" is Erik Kinnunen, and "contribution" is any code, documentation, or
-other material you submit to the project.
+In this agreement, "you" is the copyright holder making the contribution, "the maintainer" is Erik Kinnunen, and "contribution" is any code, documentation, or other material you submit to the project.
 
 ## 1. You keep your copyright
 
-You retain full ownership of your contribution. This agreement grants licenses;
-it does **not** assign or transfer your copyright.
+You retain full ownership of your contribution. This agreement grants licenses; it does **not** assign or transfer your copyright.
 
 ## 2. Copyright license
 
-You grant the maintainer a perpetual, worldwide, non-exclusive, royalty-free,
-irrevocable license to reproduce, prepare derivative works of, publicly display,
-publicly perform, sublicense, and distribute your contribution and derivative
-works of it.
+You grant the maintainer a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your contribution and derivative works of it.
 
-This license expressly includes the right to license and relicense your
-contribution under any terms the maintainer chooses, including the project's
-current open-source licenses (GPL-3.0-or-later and Apache-2.0), future
-open-source licenses, and proprietary or commercial licenses.
+This license expressly includes the right to license and relicense your contribution under any terms the maintainer chooses, including the project's current open-source licenses (GPL-3.0-or-later and Apache-2.0), future open-source licenses, and proprietary or commercial licenses.
 
 ## 3. Patent license
 
-You grant the maintainer and recipients of the software a perpetual, worldwide,
-non-exclusive, royalty-free, irrevocable (except as stated below) patent license
-to make, have made, use, offer to sell, sell, import, and otherwise transfer
-your contribution, where the license applies only to patent claims you can
-license that are necessarily infringed by your contribution alone or by its
-combination with the project. If any entity brings patent litigation alleging
-that the project or a contribution infringes a patent, the patent licenses you
-granted for that contribution terminate for that entity.
+You grant the maintainer and recipients of the software a perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except as stated below) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your contribution, where the license applies only to patent claims you can license that are necessarily infringed by your contribution alone or by its combination with the project. If any entity brings patent litigation alleging that the project or a contribution infringes a patent, the patent licenses you granted for that contribution terminate for that entity.
 
 ## 4. Your representations
 
 You represent that:
 
-- Each contribution is your original creation, or you otherwise have the right
-  to submit it under this agreement.
-- You are legally entitled to grant the licenses above. If your employer has
-  rights to work you create, you have permission to contribute on their behalf,
-  or your employer has waived those rights for your contributions.
+- Each contribution is your original creation, or you otherwise have the right to submit it under this agreement.
+- You are legally entitled to grant the licenses above. If your employer has rights to work you create, you have permission to contribute on their behalf, or your employer has waived those rights for your contributions.
 - Your contribution does not knowingly violate any third party's rights.
 
 ## 5. No obligations
 
-You provide your contribution "as is", without warranty of any kind. You are not
-expected to provide support for your contribution. The maintainer is under no
-obligation to use or merge any contribution.
+You provide your contribution "as is", without warranty of any kind. You are not expected to provide support for your contribution. The maintainer is under no obligation to use or merge any contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ That said, open source projects flourish with multiple contributors. I won't say
 
 ## AI and LLM-assisted contributions
 
-Basalt is a side project I work on for fun, and a big part of that fun is the craft of writing the code by hand. Please keep that in mind when contributing.
+Basalt is a side project I work on for fun, and one big part of that fun is also writing the code by hand. Please keep that in mind when contributing.
 
 - **Good first issues are for humans.** They are intentionally small and simple so newcomers can learn the codebase by solving them. Do not complete them with an LLM or coding agent. If you want one, program it by hand.
 - **You own what you submit.** Understand every line you open a PR with and be able to explain it. "The model wrote it" is not an answer to review feedback.
 
-Using AI as an assistant is fine in moderation. Letting it author whole contributions you don't understand is not.
+Using AI as an assistant and executor is fine. Letting it author whole contributions you don't understand is not.
 
 ## Licensing of contributions
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Basalt is a cross-platform TUI (Terminal User Interface) for managing Obsidian v
 
 Or download a pre-compiled binary from the [latest release](https://github.com/erikjuhani/basalt/releases/latest), extract it, and move the `basalt` binary to a location in your `PATH`.
 
+## Nightly builds
+
+Nightly builds track the latest `main` commit. They are unstable and meant for testing. The [`nightly` release](https://github.com/erikjuhani/basalt/releases/tag/nightly) always holds the newest build. A downloaded nightly binary reports a `-nightly` suffix in `basalt --version`. A build from source reports the commit hash instead.
+
+- Using [Homebrew](https://brew.sh) (builds from source):
+  ```sh
+  brew install --HEAD erikjuhani/tap/basalt
+  ```
+
+- Using [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) (builds from source):
+  ```sh
+  cargo install --git https://github.com/erikjuhani/basalt --branch main basalt-tui
+  ```
+
+Or download a pre-compiled binary from the [nightly release](https://github.com/erikjuhani/basalt/releases/tag/nightly).
+
 ## Configuration
 
 Basalt can be customized using a TOML configuration file. The file does not exist by default — create it manually when you want to override the defaults.

--- a/basalt/build.rs
+++ b/basalt/build.rs
@@ -1,6 +1,10 @@
 use std::{env, path::Path, process::Command};
 
 fn main() {
+    // `version.rs` reads BASALT_CHANNEL through `option_env!`, which cargo does not track for
+    // rebuilds. Declare it so a changed channel forces a recompile.
+    println!("cargo:rerun-if-env-changed=BASALT_CHANNEL");
+
     let Some(commit) = commit_info_from_git().or_else(commit_info_from_source_tarball) else {
         return;
     };

--- a/basalt/src/cli.rs
+++ b/basalt/src/cli.rs
@@ -35,6 +35,7 @@ mod tests {
                     hash: Some("abc123def0123456789"),
                     short_hash: Some("abc123def"),
                     date: Some("2026-05-15"),
+                    ..Default::default()
                 }
                 .to_string(),
             )

--- a/basalt/src/version.rs
+++ b/basalt/src/version.rs
@@ -3,6 +3,7 @@ use std::fmt;
 #[derive(Default)]
 pub struct VersionInfo {
     pub version: &'static str,
+    pub channel: Option<&'static str>,
     pub hash: Option<&'static str>,
     pub short_hash: Option<&'static str>,
     pub date: Option<&'static str>,
@@ -12,6 +13,7 @@ impl VersionInfo {
     pub const fn from_env() -> Self {
         Self {
             version: env!("CARGO_PKG_VERSION"),
+            channel: option_env!("BASALT_CHANNEL"),
             hash: option_env!("BASALT_COMMIT_HASH"),
             short_hash: option_env!("BASALT_COMMIT_SHORT_HASH"),
             date: option_env!("BASALT_COMMIT_DATE"),
@@ -22,6 +24,9 @@ impl VersionInfo {
 impl fmt::Display for VersionInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.version)?;
+        if let Some(channel) = self.channel.filter(|channel| !channel.is_empty()) {
+            write!(f, "-{channel}")?;
+        }
         match (self.short_hash, self.date) {
             (None, _) => Ok(()),
             (Some(short_hash), None) => write!(f, " ({})", short_hash),
@@ -41,8 +46,31 @@ mod tests {
             hash: Some("abc123def0123456789"),
             short_hash: Some("abc123def"),
             date: Some("2026-05-15"),
+            ..Default::default()
         };
         assert_eq!(info.to_string(), "0.12.5 (abc123def 2026-05-15)");
+    }
+
+    #[test]
+    fn with_channel() {
+        let info = VersionInfo {
+            version: "0.12.5",
+            channel: Some("nightly"),
+            short_hash: Some("abc123def"),
+            date: Some("2026-05-15"),
+            ..Default::default()
+        };
+        assert_eq!(info.to_string(), "0.12.5-nightly (abc123def 2026-05-15)");
+    }
+
+    #[test]
+    fn empty_channel_is_omitted() {
+        let info = VersionInfo {
+            version: "0.12.5",
+            channel: Some(""),
+            ..Default::default()
+        };
+        assert_eq!(info.to_string(), "0.12.5");
     }
 
     #[test]

--- a/docs/Getting started/Installation.md
+++ b/docs/Getting started/Installation.md
@@ -18,6 +18,30 @@ aqua g -i erikjuhani/basalt
 
 Download the appropriate archive for your system and architecture from [GitHub releases](https://github.com/erikjuhani/basalt/releases), extract it, and move the `basalt` binary to a location in your `PATH`.
 
+## Nightly builds
+
+Nightly builds track the latest `main` commit. They are unstable and meant for testing. The [nightly release](https://github.com/erikjuhani/basalt/releases/tag/nightly) always holds the newest build. A downloaded nightly binary reports a `-nightly` suffix in `basalt --version`. A build from source reports the commit hash instead.
+
+### Homebrew
+
+Build the latest `main` from source:
+
+```
+brew install --HEAD erikjuhani/tap/basalt
+```
+
+### Cargo
+
+Build the latest `main` from source:
+
+```
+cargo install --git https://github.com/erikjuhani/basalt --branch main basalt-tui
+```
+
+### Pre-compiled nightly binaries
+
+Download the archive for your system and architecture from the [nightly release](https://github.com/erikjuhani/basalt/releases/tag/nightly), extract it, and move the `basalt` binary to a location in your `PATH`.
+
 ## Starting Basalt
 
 Once installed, launch `basalt` from your terminal:

--- a/docs/Getting started/Installation.md
+++ b/docs/Getting started/Installation.md
@@ -1,6 +1,12 @@
 ## Installation
 
-[[Basalt]] is available to install via [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html), [aqua](https://aquaproj.github.io/docs/install), and as pre-compiled binaries from [GitHub releases](https://github.com/erikjuhani/basalt/releases).
+[[Basalt]] is available to install via [Homebrew](https://brew.sh), [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html), [aqua](https://aquaproj.github.io/docs/install) and as pre-compiled binaries from [GitHub releases](https://github.com/erikjuhani/basalt/releases).
+
+### Homebrew
+
+```
+brew install erikjuhani/tap/basalt
+```
 
 ### Cargo
 
@@ -16,7 +22,7 @@ aqua g -i erikjuhani/basalt
 
 ### Pre-compiled binaries
 
-Download the appropriate archive for your system and architecture from [GitHub releases](https://github.com/erikjuhani/basalt/releases), extract it, and move the `basalt` binary to a location in your `PATH`.
+Download the appropriate archive for your system and architecture from [GitHub releases](https://github.com/erikjuhani/basalt/releases), extract it and move the `basalt` binary to a location in your `PATH`.
 
 ## Nightly builds
 
@@ -40,7 +46,7 @@ cargo install --git https://github.com/erikjuhani/basalt --branch main basalt-tu
 
 ### Pre-compiled nightly binaries
 
-Download the archive for your system and architecture from the [nightly release](https://github.com/erikjuhani/basalt/releases/tag/nightly), extract it, and move the `basalt` binary to a location in your `PATH`.
+Download the archive for your system and architecture from the [nightly release](https://github.com/erikjuhani/basalt/releases/tag/nightly), extract it and move the `basalt` binary to a location in your `PATH`.
 
 ## Starting Basalt
 

--- a/site/_landing.md
+++ b/site/_landing.md
@@ -10,6 +10,10 @@ tagline_line2 = "vaults and notes directly from the terminal."
 demo_gif = "demo"
 
 [[extra.install_commands]]
+label = "brew"
+cmd = "brew install erikjuhani/tap/basalt"
+
+[[extra.install_commands]]
 label = "cargo"
 cmd = "cargo install basalt-tui"
 


### PR DESCRIPTION
Adds a nightly release channel.

- **`nightly.yml`**: builds on every push to `main` (plus manual dispatch), force-moves a `nightly` tag, and updates one rolling prerelease. `concurrency: cancel-in-progress` supersedes an in-flight run.
- **`build.yml`**: gains optional `version` and `channel` inputs. `version` names artifacts for tagless builds, `channel` bakes into the binary. Defaults keep `release.yml` unchanged.
- **Binary**: `basalt --version` reports `0.12.7-nightly (<sha> <date>)` on nightly builds. Stable and local builds are unaffected.

Homebrew is untouched. The tap step lives only in `release.yml`, which nightly never invokes.

Open question: nightly builds the full 9-target matrix on every merge. Trim it to save CI minutes, or keep full coverage?