### PR TITLE
Match title text to the symbol preset

### DIFF
--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -920,7 +920,8 @@ impl<'a> App<'a> {
     ) {
         let border_modal = self.config.symbols.border_modal.into();
         let vault_active = self.config.symbols.vault_active.clone();
-        SplashModal::new(border_modal, vault_active, theme).render(area, buf, state)
+        let preset = self.config.symbols.preset;
+        SplashModal::new(border_modal, vault_active, theme, preset).render(area, buf, state)
     }
 
     fn render_main(&self, area: Rect, buf: &mut Buffer, state: &mut AppState<'a>) {

--- a/basalt/src/config/symbol.rs
+++ b/basalt/src/config/symbol.rs
@@ -6,7 +6,7 @@ use crate::{
     stylized_text::FontStyle,
 };
 
-#[derive(Clone, Debug, PartialEq, Default, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Preset {
     #[default]

--- a/basalt/src/header.rs
+++ b/basalt/src/header.rs
@@ -55,7 +55,12 @@ impl Widget for Header<'_, '_> {
             .style(Style::new().bg(self.theme.background))
             .render(area, buf);
 
-        let brand = Line::from(Span::from(" ⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅ ").fg(self.theme.accent).bold());
+        let brand_text = if self.symbols.preset == Preset::Ascii {
+            " Basalt "
+        } else {
+            " ⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅ "
+        };
+        let brand = Line::from(Span::from(brand_text).fg(self.theme.accent).bold());
 
         let brand_width = (brand.width() as u16).min(area.width);
         let [brand_area, tabs_area] =

--- a/basalt/src/splash_modal.rs
+++ b/basalt/src/splash_modal.rs
@@ -11,7 +11,7 @@ use ratatui::{
 
 use crate::{
     app::Message as AppMessage,
-    config::Theme,
+    config::{symbol::Preset, Theme},
     vault_selector::{VaultSelector, VaultSelectorState},
 };
 
@@ -39,6 +39,7 @@ pub fn update<'a>(message: &Message, state: &mut SplashModalState<'a>) -> Option
 }
 
 const TITLE: &str = "⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅";
+const TITLE_ASCII: &str = "Basalt";
 
 pub const LOGO: [&str; 25] = [
     "           ▒███▓░          ",
@@ -126,15 +127,22 @@ pub struct SplashModal<'a> {
     pub border_type: BorderType,
     pub vault_active: String,
     pub theme: Theme,
+    pub preset: Preset,
 }
 
 impl<'a> SplashModal<'a> {
-    pub fn new(border_type: BorderType, vault_active: String, theme: Theme) -> Self {
+    pub fn new(
+        border_type: BorderType,
+        vault_active: String,
+        theme: Theme,
+        preset: Preset,
+    ) -> Self {
         Self {
             _lifetime: PhantomData,
             border_type,
             vault_active,
             theme,
+            preset,
         }
     }
 }
@@ -185,7 +193,15 @@ impl<'a> StatefulWidget for SplashModal<'a> {
         let muted = self.theme.muted;
         Text::from_iter(LOGO).fg(muted).centered().render(logo, buf);
 
-        Text::from(TITLE).fg(muted).centered().render(title, buf);
+        let title_text = if self.preset == Preset::Ascii {
+            TITLE_ASCII
+        } else {
+            TITLE
+        };
+        Text::from(title_text)
+            .fg(muted)
+            .centered()
+            .render(title, buf);
 
         Text::from(state.version)
             .fg(muted)


### PR DESCRIPTION
The `⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅` title was hardcoded in the header and splash modal. With the `ascii` preset it still emitted the dot operator and Fraktur-bold glyphs on terminals that cannot render them. Both sites now fall back to plain `Basalt` when the preset is `Ascii`, and keep the stylized form for `unicode` and `nerd-font`.