### PR TITLE
Use the real terminal cursor for text editing

### DIFF
--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -1,8 +1,12 @@
 use basalt_core::obsidian::{self, create_untitled_dir, create_untitled_note, Note, Vault};
 use ratatui::{
     buffer::Buffer,
-    crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
-    layout::{Constraint, Flex, Layout, Rect, Size},
+    crossterm::{
+        cursor::SetCursorStyle,
+        event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+        execute,
+    },
+    layout::{Constraint, Flex, Layout, Position, Rect, Size},
     style::Style,
     widgets::{Block, StatefulWidget, Widget},
     DefaultTerminal,
@@ -29,7 +33,7 @@ use crate::{
     note_editor::{
         self, ast,
         editor::NoteEditor,
-        state::{EditMode, NoteEditorState, View},
+        state::{EditMode, Mode, NoteEditorState, View},
     },
     outline::{self, Outline, OutlineState},
     splash_modal::{self, SplashModal, SplashModalState},
@@ -272,6 +276,33 @@ fn active_config_section<'a>(
     }
 }
 
+fn focused_cursor(state: &AppState) -> Option<Position> {
+    match state.active_component() {
+        ActivePane::NoteEditor => state
+            .tabs
+            .active_editor()
+            .and_then(|editor| editor.terminal_cursor),
+        ActivePane::Input => state.input_modal.terminal_cursor,
+        _ => None,
+    }
+}
+
+fn cursor_style(state: &AppState) -> SetCursorStyle {
+    let inserting = match state.active_component() {
+        ActivePane::NoteEditor => matches!(
+            state.tabs.active_editor().map(NoteEditorState::mode),
+            Some(Mode::Insert | Mode::Edit)
+        ),
+        ActivePane::Input => state.input_modal.is_editing(),
+        _ => false,
+    };
+    if inserting {
+        SetCursorStyle::SteadyBar
+    } else {
+        SetCursorStyle::SteadyBlock
+    }
+}
+
 fn rebuild_outline(state: &mut AppState, config: &Config) {
     let is_open = state.outline.is_open();
     let was_active = state.outline.active;
@@ -486,11 +517,18 @@ impl<'a> App<'a> {
     fn draw(&self, state: &mut AppState<'a>) -> Result<()> {
         let mut terminal = self.terminal.borrow_mut();
 
-        terminal.draw(move |frame| {
+        terminal.draw(|frame| {
             let area = frame.area();
-            let buf = frame.buffer_mut();
-            self.render(area, buf, state);
+            self.render(area, frame.buffer_mut(), state);
+
+            if let Some(position) = focused_cursor(state) {
+                frame.set_cursor_position(position);
+            }
         })?;
+
+        if focused_cursor(state).is_some() {
+            execute!(terminal.backend_mut(), cursor_style(state))?;
+        }
 
         Ok(())
     }

--- a/basalt/src/input/mod.rs
+++ b/basalt/src/input/mod.rs
@@ -37,6 +37,7 @@ pub struct InputModalState {
     label: String,
     offset_x: usize,
     callback: Option<Callback>,
+    pub(crate) terminal_cursor: Option<Position>,
 }
 
 impl InputModalState {
@@ -53,6 +54,7 @@ impl InputModalState {
             visible,
             label: String::from("Input"),
             callback: None,
+            terminal_cursor: None,
         }
     }
 
@@ -299,6 +301,7 @@ impl Input {
 impl StatefulWidget for Input {
     type State = InputModalState;
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        state.terminal_cursor = None;
         if !state.visible {
             return;
         }
@@ -377,12 +380,9 @@ impl StatefulWidget for Input {
             )
             .render(area, buf);
 
-        // FIXME: When drawing the input above
-        buf.set_style(
-            Rect::new(col.saturating_sub(state.scroll as u16), row, 1, 1)
-                .offset(Offset { x: 2, y: 1 }),
-            Style::default().reversed().fg(self.theme.muted),
-        );
+        let cursor = Rect::new(col.saturating_sub(state.scroll as u16), row, 1, 1)
+            .offset(Offset { x: 2, y: 1 });
+        state.terminal_cursor = Some(Position::new(cursor.x, cursor.y));
     }
 }
 

--- a/basalt/src/main.rs
+++ b/basalt/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use basalt_core::obsidian::{self, Error, Vault};
 use basalt_tui::{app::App, cli::Cli, debug_log};
+use ratatui::crossterm::{cursor::SetCursorStyle, execute};
 
 fn main() -> Result<(), Error> {
     let cli = Cli::parse();
@@ -30,19 +31,21 @@ fn main() -> Result<(), Error> {
         Err(_) => None,
     };
 
-    let mut terminal = ratatui::init();
-    terminal.show_cursor()?;
+    let terminal = ratatui::init();
 
-    App::start(
+    let result = App::start(
         terminal,
         vaults,
         initial_vault,
         cli.debug,
         cli.log_level,
         cli.theme,
-    )?;
+    );
 
+    let _ = execute!(std::io::stdout(), SetCursorStyle::DefaultUserShape);
     ratatui::restore();
+
+    result?;
 
     Ok(())
 }

--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -24,7 +24,7 @@ pub enum Message {
     SwitchMode(CursorMode),
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum CursorMode {
     #[default]
     Read,
@@ -374,28 +374,19 @@ impl StatefulWidget for CursorWidget {
     where
         Self: Sized,
     {
+        if !matches!(state.mode, CursorMode::Read) {
+            return;
+        }
+
         let y = (state.virtual_row as u16)
             .saturating_add(self.meta_len)
             .saturating_sub(area.top())
             .saturating_add(self.offset.y as u16);
 
-        match state.mode {
-            CursorMode::Read => {
-                buf.set_style(
-                    Rect::new(self.offset.x as u16, y, area.width, 1),
-                    Style::default().reversed().fg(self.selection),
-                );
-            }
-            CursorMode::Edit => {
-                let x = (state.virtual_column as u16)
-                    .saturating_add(self.offset.x as u16)
-                    .saturating_sub(area.left());
-                buf.set_style(
-                    Rect::new(x, y, 1, 1),
-                    Style::default().reversed().fg(self.selection),
-                );
-            }
-        }
+        buf.set_style(
+            Rect::new(self.offset.x as u16, y, area.width, 1),
+            Style::default().reversed().fg(self.selection),
+        );
     }
 }
 

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, ops::Range};
 
 use ratatui::{
     buffer::Buffer,
-    layout::{Offset, Rect},
+    layout::{Offset, Position, Rect},
     style::{Color, Style, Stylize},
     text::{Line, Span},
     widgets::{
@@ -13,7 +13,10 @@ use ratatui::{
 use unicode_width::UnicodeWidthChar;
 
 use crate::note_editor::{
-    cursor::CursorWidget, state::NoteEditorState, viewport::Viewport, virtual_document::VirtualLine,
+    cursor::{CursorMode, CursorWidget},
+    state::NoteEditorState,
+    viewport::Viewport,
+    virtual_document::VirtualLine,
 };
 
 const SELECTION_STYLE: Style = Style::new().reversed();
@@ -178,15 +181,30 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
             );
         }
 
+        state.terminal_cursor = None;
         if !state.content.is_empty() || state.is_editing() {
-            CursorWidget::default()
-                .with_offset(Offset {
-                    x: inner_area.x as i32,
-                    y: inner_area.y as i32,
-                })
-                .with_meta_len(meta_lines_count as u16)
-                .with_theme(&theme)
-                .render(state.viewport().area(), buf, &mut state.cursor);
+            match *state.cursor.mode() {
+                CursorMode::Read => CursorWidget::default()
+                    .with_offset(Offset {
+                        x: inner_area.x as i32,
+                        y: inner_area.y as i32,
+                    })
+                    .with_meta_len(meta_lines_count as u16)
+                    .with_theme(&theme)
+                    .render(state.viewport().area(), buf, &mut state.cursor),
+                CursorMode::Edit => {
+                    let scroll = state.viewport().area();
+                    let y = (state.cursor.virtual_row() as u16)
+                        .saturating_add(meta_lines_count as u16)
+                        .saturating_sub(scroll.top())
+                        .saturating_add(inner_area.y);
+                    let x = (state.cursor.virtual_column() as u16)
+                        .saturating_add(inner_area.x)
+                        .saturating_sub(scroll.left());
+                    let position = Position { x, y };
+                    state.terminal_cursor = inner_area.contains(position).then_some(position);
+                }
+            }
         }
 
         if !area.is_empty() && total_lines as u16 > inner_area.bottom() {

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -8,7 +8,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ratatui::{layout::Size, style::Color};
+use ratatui::{
+    layout::{Position, Size},
+    style::Color,
+};
 
 use crate::{
     config::{Symbols, Theme},
@@ -184,6 +187,7 @@ pub struct NoteEditorState<'a> {
     /// the layout always matches the text_buffer, even when the cursor
     /// position would temporarily resolve to a different block.
     editing_block: Option<usize>,
+    pub(crate) terminal_cursor: Option<Position>,
 }
 
 impl<'a> NoteEditorState<'a> {
@@ -217,6 +221,7 @@ impl<'a> NoteEditorState<'a> {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             editing_block: None,
+            terminal_cursor: None,
         }
     }
 


### PR DESCRIPTION
Replace the painted cursor in the note editor and input modal with the terminal's own cursor. Read view keeps its full-line highlight; edit view uses the real cursor. Narrow bar while inserting, block otherwise, restored to default on exit.