### PR TITLE
Move note editor cursor by whole lines, add gj/gk for screen rows

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [0.13.0](https://github.com/erikjuhani/basalt/releases/tag/basalt/0.13.0) (Unreleased)
 
+### Added
+
+- [7f3e7c3](https://github.com/erikjuhani/basalt/commit/7f3e7c3ec46026672c2f74fc9f59daf62c245cbb) Move note editor cursor by whole lines, add gj/gk for screen rows by @erikjuhani
+
+> j/k now move by whole soft-wrapped lines, matching Vim. On the first line,
+> k goes to line start; on the last line, j goes to line end. New gj/gk
+> motions move by single visible rows. Screen movement drives half-page
+> scroll and jump-to-top so the viewport tracks rows.
+>
+> Wrap continuation is derived from a typed VirtualSpan::WrapMarker span
+> produced only by render, replacing the stored wrap_continuation flag.
+
 ### Changed
 
 - [27bdefa](https://github.com/erikjuhani/basalt/commit/27bdefa3cc2b7d98380ec4577f29d45ecb25029e) Memoize note layout instead of rebuilding it every frame by @erikjuhani

--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -52,6 +52,10 @@
 #
 # Note editor commands:
 #
+# note_editor_cursor_up: moves cursor up one line (whole soft-wrapped line)
+# note_editor_cursor_down: moves cursor down one line (whole soft-wrapped line)
+# note_editor_cursor_screen_up: moves cursor up one visible row (Vim gk)
+# note_editor_cursor_screen_down: moves cursor down one visible row (Vim gj)
 # note_editor_scroll_up_one: scrolls up by one
 # note_editor_scroll_down_one: scrolls down by one
 # note_editor_scroll_up_half_page: scrolls up by half page
@@ -221,6 +225,8 @@ key_bindings = [
 key_bindings = [
  { key = "k", command = "note_editor_cursor_up" },
  { key = "j", command = "note_editor_cursor_down" },
+ { key = "gk", command = "note_editor_cursor_screen_up" },
+ { key = "gj", command = "note_editor_cursor_screen_down" },
  { key = "up", command = "note_editor_cursor_up" },
  { key = "down", command = "note_editor_cursor_down" },
  { key = "t", command = "note_editor_toggle_explorer" },

--- a/basalt/src/command.rs
+++ b/basalt/src/command.rs
@@ -79,6 +79,8 @@ pub(crate) enum Command {
     NoteEditorToggleOutline,
     NoteEditorCursorUp,
     NoteEditorCursorDown,
+    NoteEditorCursorScreenUp,
+    NoteEditorCursorScreenDown,
     NoteEditorScrollToTop,
     NoteEditorScrollToBottom,
 
@@ -226,6 +228,8 @@ fn str_to_command(s: &str) -> Option<Command> {
         "note_editor_toggle_outline" => Some(Command::NoteEditorToggleOutline),
         "note_editor_cursor_up" => Some(Command::NoteEditorCursorUp),
         "note_editor_cursor_down" => Some(Command::NoteEditorCursorDown),
+        "note_editor_cursor_screen_up" => Some(Command::NoteEditorCursorScreenUp),
+        "note_editor_cursor_screen_down" => Some(Command::NoteEditorCursorScreenDown),
         "note_editor_scroll_to_top" => Some(Command::NoteEditorScrollToTop),
         "note_editor_scroll_to_bottom" => Some(Command::NoteEditorScrollToBottom),
 
@@ -440,6 +444,12 @@ impl From<Command> for Message<'_> {
             }
             Command::NoteEditorCursorUp => Message::NoteEditor(note_editor::Message::CursorUp),
             Command::NoteEditorCursorDown => Message::NoteEditor(note_editor::Message::CursorDown),
+            Command::NoteEditorCursorScreenUp => {
+                Message::NoteEditor(note_editor::Message::CursorScreenUp)
+            }
+            Command::NoteEditorCursorScreenDown => {
+                Message::NoteEditor(note_editor::Message::CursorScreenDown)
+            }
             Command::NoteEditorScrollToTop => {
                 Message::NoteEditor(note_editor::Message::ScrollToTop)
             }

--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -15,13 +15,19 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub enum Message {
-    MoveUp(usize),
-    MoveDown(usize),
+    MoveUp(usize, LineMovement),
+    MoveDown(usize, LineMovement),
     MoveLeft(usize),
     MoveRight(usize),
     /// Jump the cursor according to the given byte index
     Jump(usize),
     SwitchMode(CursorMode),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LineMovement {
+    Visual,
+    Logical,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -138,6 +144,16 @@ pub fn source_offset_to_virtual_column<'a>(offset: usize, line: &VirtualLine<'a>
     virtual_col.break_value()
 }
 
+fn has_content(lines: &[VirtualLine], idx: usize) -> bool {
+    lines.get(idx).is_some_and(VirtualLine::has_content)
+}
+
+fn is_line_head(lines: &[VirtualLine], idx: usize) -> bool {
+    lines
+        .get(idx)
+        .is_some_and(|line| line.has_content() && !line.is_wrap_continuation())
+}
+
 pub(crate) fn snap_to_char_boundary(text: &str, offset: usize) -> usize {
     let offset = offset.min(text.len());
     (offset..=text.len())
@@ -160,6 +176,61 @@ impl Cursor {
             }
             self.virtual_row = row
         }
+    }
+
+    fn place_on_row(&mut self, idx: usize, lines: &[VirtualLine]) {
+        let Some(line) = lines.get(idx) else { return };
+        self.virtual_row = idx;
+
+        let Some(source_range) = line.source_range() else {
+            return;
+        };
+
+        match self.mode() {
+            CursorMode::Read => self.source_offset = source_range.start,
+            CursorMode::Edit => {
+                if let Some(offset) = virtual_position_to_source_offset(
+                    (self.virtual_row, self.virtual_column),
+                    lines,
+                ) {
+                    self.source_offset = offset;
+                    if let Some(col) = source_offset_to_virtual_column(self.source_offset, line) {
+                        self.virtual_column = col;
+                    }
+                }
+            }
+        }
+    }
+
+    fn place_at_line_start(&mut self, head: usize, lines: &[VirtualLine]) {
+        let Some(line) = lines.get(head) else { return };
+        let Some(source_range) = line.source_range() else {
+            return;
+        };
+        self.virtual_row = head;
+        self.source_offset = source_range.start;
+        self.virtual_column =
+            source_offset_to_virtual_column(source_range.start, line).unwrap_or(0);
+    }
+
+    fn place_at_line_end(&mut self, lines: &[VirtualLine]) {
+        let next_head = (self.virtual_row + 1..lines.len())
+            .find(|&idx| is_line_head(lines, idx))
+            .unwrap_or(lines.len());
+        let last_row = (self.virtual_row..next_head)
+            .rev()
+            .find(|&idx| has_content(lines, idx))
+            .unwrap_or(self.virtual_row);
+
+        let Some(line) = lines.get(last_row) else {
+            return;
+        };
+        let Some(source_range) = line.source_range() else {
+            return;
+        };
+        self.virtual_row = last_row;
+        self.source_offset = source_range.end;
+        self.virtual_column = source_offset_to_virtual_column(source_range.end, line).unwrap_or(0);
     }
 
     pub fn update(
@@ -211,77 +282,62 @@ impl Cursor {
             // TODO: Applies to both cursor_up and cursor_down
             // The cursor should always be fixed to the viewport. This would enable easier implementation
             // for e.g. search feature when navigating between matches
-            MoveUp(amount) => {
+            MoveUp(amount, LineMovement::Visual) => {
                 let current_idx = self.virtual_row;
                 let target_idx = current_idx.saturating_sub(amount);
 
                 // Search downward from target, then upward if no content line found
-                let iter = (0..=target_idx).rev().chain(target_idx + 1..current_idx);
+                let candidate = (0..=target_idx)
+                    .rev()
+                    .chain(target_idx + 1..current_idx)
+                    .find(|&idx| has_content(lines, idx));
 
-                for idx in iter {
-                    if let Some(line) = lines.get(idx).filter(|line| line.has_content()) {
-                        self.virtual_row = idx;
-
-                        if let Some(source_range) = line.source_range() {
-                            match self.mode() {
-                                CursorMode::Read => self.source_offset = source_range.start,
-                                CursorMode::Edit => {
-                                    if let Some(offset) = virtual_position_to_source_offset(
-                                        (self.virtual_row, self.virtual_column),
-                                        lines,
-                                    ) {
-                                        self.source_offset = offset;
-                                        if let Some(col) = source_offset_to_virtual_column(
-                                            self.source_offset,
-                                            line,
-                                        ) {
-                                            self.virtual_column = col;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        return;
-                    }
+                if let Some(idx) = candidate {
+                    self.place_on_row(idx, lines);
                 }
             }
 
             // TODO: Implement scroll offset so that the file scroll offset can be changed by moving
             // cursor downwards when we are at the bottom.
-            MoveDown(amount) => {
+            MoveDown(amount, LineMovement::Visual) => {
                 let current_idx = self.virtual_row;
                 let target_idx = current_idx.saturating_add(amount).min(lines.len());
 
                 // Search forward from target, then backward if no content line found
-                let iter = (target_idx..lines.len()).chain((current_idx + 1..target_idx).rev());
+                let candidate = (target_idx..lines.len())
+                    .chain((current_idx + 1..target_idx).rev())
+                    .find(|&idx| has_content(lines, idx));
 
-                for idx in iter {
-                    if let Some(line) = lines.get(idx).filter(|line| line.has_content()) {
-                        self.virtual_row = idx;
+                if let Some(idx) = candidate {
+                    self.place_on_row(idx, lines);
+                }
+            }
 
-                        if let Some(source_range) = line.source_range() {
-                            match self.mode() {
-                                CursorMode::Read => self.source_offset = source_range.start,
-                                CursorMode::Edit => {
-                                    if let Some(offset) = virtual_position_to_source_offset(
-                                        (self.virtual_row, self.virtual_column),
-                                        lines,
-                                    ) {
-                                        self.source_offset = offset;
-                                        if let Some(col) = source_offset_to_virtual_column(
-                                            self.source_offset,
-                                            line,
-                                        ) {
-                                            self.virtual_column = col;
-                                        }
-                                    }
-                                }
-                            }
-                        }
+            MoveUp(amount, LineMovement::Logical) => {
+                let current_head = (0..=self.virtual_row)
+                    .rev()
+                    .find(|&idx| is_line_head(lines, idx))
+                    .unwrap_or(self.virtual_row);
 
-                        return;
-                    }
+                match (0..current_head)
+                    .rev()
+                    .filter(|&idx| is_line_head(lines, idx))
+                    .take(amount)
+                    .last()
+                {
+                    Some(idx) => self.place_on_row(idx, lines),
+                    None => self.place_at_line_start(current_head, lines),
+                }
+            }
+
+            MoveDown(amount, LineMovement::Logical) => {
+                match (self.virtual_row + 1..lines.len())
+                    .filter(|&idx| is_line_head(lines, idx))
+                    .take(amount)
+                    .last()
+                {
+                    Some(idx) => self.place_on_row(idx, lines),
+                    None => self.place_at_line_end(lines),
                 }
             }
 
@@ -438,7 +494,9 @@ mod tests {
             .virtual_spans()
             .iter()
             .map(|span| match span {
-                VirtualSpan::Content(s, _) | VirtualSpan::Synthetic(s) => s.content.to_string(),
+                VirtualSpan::Content(s, _)
+                | VirtualSpan::Synthetic(s)
+                | VirtualSpan::WrapMarker(s) => s.content.to_string(),
             })
             .collect();
 
@@ -624,13 +682,21 @@ mod tests {
         assert_eq!(cursor.virtual_row, 3);
 
         // Move up to empty line
-        cursor.update(Message::MoveUp(1), &lines, &Some(text_buffer.clone()));
+        cursor.update(
+            Message::MoveUp(1, LineMovement::Visual),
+            &lines,
+            &Some(text_buffer.clone()),
+        );
         assert_eq!(cursor.virtual_row, 2);
         // Source offset should be within empty line's range (14..15)
         assert_eq!(cursor.source_offset, 14);
 
         // Move up to line1
-        cursor.update(Message::MoveUp(1), &lines, &Some(text_buffer));
+        cursor.update(
+            Message::MoveUp(1, LineMovement::Visual),
+            &lines,
+            &Some(text_buffer),
+        );
         assert_eq!(cursor.virtual_row, 1);
     }
 
@@ -646,7 +712,11 @@ mod tests {
         cursor.update_virtual_position(&lines);
         assert_eq!(cursor.virtual_row, 2);
 
-        cursor.update(Message::MoveUp(1), &lines, &Some(text_buffer));
+        cursor.update(
+            Message::MoveUp(1, LineMovement::Visual),
+            &lines,
+            &Some(text_buffer),
+        );
         assert_eq!(cursor.virtual_row, 1);
     }
 
@@ -683,10 +753,119 @@ mod tests {
         cursor.update_virtual_position(&lines);
         assert_eq!(cursor.virtual_row, 3);
 
-        cursor.update(Message::MoveUp(1), &lines, &None);
+        cursor.update(Message::MoveUp(1, LineMovement::Visual), &lines, &None);
         assert_eq!(cursor.virtual_row, 2);
 
-        cursor.update(Message::MoveUp(1), &lines, &None);
+        cursor.update(Message::MoveUp(1, LineMovement::Visual), &lines, &None);
         assert_eq!(cursor.virtual_row, 1);
+    }
+
+    fn render_lines_width(content: &str, width: usize) -> Vec<VirtualLine<'static>> {
+        parser::from_str(content)
+            .into_iter()
+            .flat_map(|node| {
+                render_node(
+                    content,
+                    &node,
+                    width,
+                    0,
+                    Span::default(),
+                    &RenderStyle::Raw,
+                    &Symbols::unicode(),
+                    &Theme::default(),
+                    0,
+                )
+                .lines
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_logical_movement_skips_wrapped_rows() {
+        let content = "alpha bravo charlie delta echo\nsecond line";
+        let lines = render_lines_width(content, 12);
+
+        assert!(lines.iter().any(VirtualLine::is_wrap_continuation));
+
+        let heads: Vec<usize> = (0..lines.len())
+            .filter(|&idx| is_line_head(&lines, idx))
+            .collect();
+        assert_eq!(heads.len(), 2);
+
+        let mut cursor = Cursor::new(0);
+        cursor.mode = CursorMode::Edit;
+        cursor.update_virtual_position(&lines);
+        assert_eq!(cursor.virtual_row, heads[0]);
+
+        cursor.update(Message::MoveDown(1, LineMovement::Logical), &lines, &None);
+        assert_eq!(cursor.virtual_row, heads[1]);
+
+        cursor.update(Message::MoveUp(1, LineMovement::Logical), &lines, &None);
+        assert_eq!(cursor.virtual_row, heads[0]);
+    }
+
+    #[test]
+    fn test_logical_up_from_continuation_row() {
+        let content = "alpha bravo charlie delta echo\nsecond line";
+        let lines = render_lines_width(content, 12);
+        let heads: Vec<usize> = (0..lines.len())
+            .filter(|&idx| is_line_head(&lines, idx))
+            .collect();
+
+        let continuation = heads[0] + 1;
+        assert!(lines[continuation].is_wrap_continuation());
+
+        let mut cursor = Cursor::new(0);
+        cursor.mode = CursorMode::Edit;
+        cursor.virtual_row = continuation;
+
+        cursor.update(Message::MoveUp(1, LineMovement::Logical), &lines, &None);
+        assert_eq!(cursor.virtual_row, heads[0]);
+    }
+
+    #[test]
+    fn test_logical_up_on_first_line_goes_to_start() {
+        let content = "alpha bravo charlie delta echo\nsecond line";
+        let lines = render_lines_width(content, 12);
+
+        let mut cursor = Cursor::new(6);
+        cursor.mode = CursorMode::Edit;
+        cursor.update_virtual_position(&lines);
+
+        cursor.update(Message::MoveUp(1, LineMovement::Logical), &lines, &None);
+        assert_eq!(cursor.source_offset, 0);
+        assert!(is_line_head(&lines, cursor.virtual_row));
+    }
+
+    #[test]
+    fn test_logical_down_on_last_line_goes_to_end() {
+        let content = "alpha bravo charlie delta echo\nsecond line";
+        let lines = render_lines_width(content, 12);
+
+        let last_line_start = content.find("second").unwrap();
+        let mut cursor = Cursor::new(last_line_start);
+        cursor.mode = CursorMode::Edit;
+        cursor.update_virtual_position(&lines);
+
+        cursor.update(Message::MoveDown(1, LineMovement::Logical), &lines, &None);
+        assert_eq!(cursor.source_offset, content.len());
+    }
+
+    #[test]
+    fn test_visual_movement_steps_one_wrapped_row() {
+        let content = "alpha bravo charlie delta echo\nsecond line";
+        let lines = render_lines_width(content, 12);
+        let heads: Vec<usize> = (0..lines.len())
+            .filter(|&idx| is_line_head(&lines, idx))
+            .collect();
+
+        let mut cursor = Cursor::new(0);
+        cursor.mode = CursorMode::Edit;
+        cursor.update_virtual_position(&lines);
+
+        cursor.update(Message::MoveDown(1, LineMovement::Visual), &lines, &None);
+        assert_eq!(cursor.virtual_row, heads[0] + 1);
+        assert!(lines[cursor.virtual_row].is_wrap_continuation());
+        assert!(cursor.virtual_row < heads[1]);
     }
 }

--- a/basalt/src/note_editor/mod.rs
+++ b/basalt/src/note_editor/mod.rs
@@ -47,6 +47,8 @@ pub enum Message {
     CursorWordForward,
     CursorWordBackward,
     CursorDown,
+    CursorScreenUp,
+    CursorScreenDown,
     ScrollUp(ScrollAmount),
     ScrollDown(ScrollAmount),
     ScrollToTop,
@@ -339,22 +341,32 @@ pub fn update<'a>(
             state.cursor_down(count);
             return select_at_cursor(state);
         }
+        Message::CursorScreenUp => {
+            let count = state.take_count().unwrap_or(1);
+            state.cursor_up_screen(count);
+            return select_at_cursor(state);
+        }
+        Message::CursorScreenDown => {
+            let count = state.take_count().unwrap_or(1);
+            state.cursor_down_screen(count);
+            return select_at_cursor(state);
+        }
         Message::ScrollUp(scroll_amount) => {
-            state.cursor_up(calc_scroll_amount(
+            state.cursor_up_screen(calc_scroll_amount(
                 &scroll_amount,
                 screen_size.height.into(),
             ));
             return select_at_cursor(state);
         }
         Message::ScrollDown(scroll_amount) => {
-            state.cursor_down(calc_scroll_amount(
+            state.cursor_down_screen(calc_scroll_amount(
                 &scroll_amount,
                 screen_size.height.into(),
             ));
             return select_at_cursor(state);
         }
         Message::ScrollToTop => {
-            state.cursor_up(usize::MAX);
+            state.cursor_up_screen(usize::MAX);
             return select_at_cursor(state);
         }
         Message::ScrollToBottom => {

--- a/basalt/src/note_editor/render.rs
+++ b/basalt/src/note_editor/render.rs
@@ -12,8 +12,8 @@ use crate::{
         rich_text::RichText,
         text_wrap::wrap_preserve_trailing,
         virtual_document::{
-            content_span, empty_virtual_line, synthetic_span, virtual_line, VirtualBlock,
-            VirtualLine, VirtualSpan,
+            content_span, empty_virtual_line, synthetic_span, virtual_line, wrap_marker_span,
+            VirtualBlock, VirtualLine, VirtualSpan,
         },
     },
     stylized_text::stylize,
@@ -99,7 +99,7 @@ fn text_wrap_internal<'a>(
                     virtual_line!([
                         synthetic_span!(prefix),
                         synthetic_span!(Span::styled(" ".repeat(marker_padding), prefix.style)),
-                        synthetic_span!(Span::styled(wrap_marker.clone(), Style::new().black())),
+                        wrap_marker_span!(Span::styled(wrap_marker.clone(), Style::new().black())),
                         content_span!(content_span, line_source_range)
                     ])
                 }

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -1040,12 +1040,12 @@ impl<'a> NoteEditorState<'a> {
         );
     }
 
-    pub fn cursor_up(&mut self, amount: usize) {
+    fn move_up(&mut self, amount: usize, movement: cursor::LineMovement) {
         let prev_block_idx = self.current_block_idx();
         let prev_row = self.cursor.virtual_row();
 
         self.cursor.update(
-            cursor::Message::MoveUp(amount),
+            cursor::Message::MoveUp(amount, movement),
             self.virtual_document.lines(),
             &self.text_buffer,
         );
@@ -1056,17 +1056,33 @@ impl<'a> NoteEditorState<'a> {
         self.ensure_cursor_visible();
     }
 
-    pub fn cursor_down(&mut self, amount: usize) {
+    fn move_down(&mut self, amount: usize, movement: cursor::LineMovement) {
         let prev_block_idx = self.current_block_idx();
 
         self.cursor.update(
-            cursor::Message::MoveDown(amount),
+            cursor::Message::MoveDown(amount, movement),
             self.virtual_document.lines(),
             &self.text_buffer,
         );
 
         self.relayout_on_block_change(prev_block_idx);
         self.ensure_cursor_visible();
+    }
+
+    pub fn cursor_up(&mut self, amount: usize) {
+        self.move_up(amount, cursor::LineMovement::Logical);
+    }
+
+    pub fn cursor_down(&mut self, amount: usize) {
+        self.move_down(amount, cursor::LineMovement::Logical);
+    }
+
+    pub fn cursor_up_screen(&mut self, amount: usize) {
+        self.move_up(amount, cursor::LineMovement::Visual);
+    }
+
+    pub fn cursor_down_screen(&mut self, amount: usize) {
+        self.move_down(amount, cursor::LineMovement::Visual);
     }
 
     /// Re-layout while editing so the raw (source) line tracks the cursor.

--- a/basalt/src/note_editor/virtual_document.rs
+++ b/basalt/src/note_editor/virtual_document.rs
@@ -34,6 +34,12 @@ macro_rules! synthetic_span {
     }};
 }
 
+macro_rules! wrap_marker_span {
+    ($span:expr) => {{
+        VirtualSpan::WrapMarker($span.clone().into())
+    }};
+}
+
 macro_rules! virtual_line {
     ($visual_spans:expr) => {{
         VirtualLine::new(&$visual_spans)
@@ -50,10 +56,12 @@ pub(crate) use content_span;
 pub(crate) use empty_virtual_line;
 pub(crate) use synthetic_span;
 pub(crate) use virtual_line;
+pub(crate) use wrap_marker_span;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum VirtualSpan<'a> {
     Synthetic(Span<'a>),
+    WrapMarker(Span<'a>),
     Content(Span<'a>, SourceRange<usize>),
 }
 
@@ -68,27 +76,29 @@ impl VirtualSpan<'_> {
     pub fn chars(&self) -> Chars<'_> {
         match self {
             Self::Content(span, ..) => span.content.chars(),
-            Self::Synthetic(..) => "".chars(),
+            Self::Synthetic(..) | Self::WrapMarker(..) => "".chars(),
         }
     }
 
     pub fn char_indices(&self) -> CharIndices<'_> {
         match self {
             Self::Content(span, ..) => span.content.char_indices(),
-            Self::Synthetic(..) => "".char_indices(),
+            Self::Synthetic(..) | Self::WrapMarker(..) => "".char_indices(),
         }
     }
 
     pub fn source_range(&self) -> Option<&SourceRange<usize>> {
         match self {
             Self::Content(.., source_range) => Some(source_range),
-            Self::Synthetic(..) => None,
+            Self::Synthetic(..) | Self::WrapMarker(..) => None,
         }
     }
 
     pub fn width(&self) -> usize {
         let span = match self {
-            VirtualSpan::Content(span, ..) | VirtualSpan::Synthetic(span) => span,
+            VirtualSpan::Content(span, ..)
+            | VirtualSpan::Synthetic(span)
+            | VirtualSpan::WrapMarker(span) => span,
         };
         // A tab is one byte but rendered as two columns (expanded at draw time).
         span.content
@@ -98,14 +108,23 @@ impl VirtualSpan<'_> {
     }
 
     pub fn is_synthetic(&self) -> bool {
-        matches!(self, VirtualSpan::Synthetic(..))
+        matches!(
+            self,
+            VirtualSpan::Synthetic(..) | VirtualSpan::WrapMarker(..)
+        )
+    }
+
+    pub fn is_wrap_marker(&self) -> bool {
+        matches!(self, VirtualSpan::WrapMarker(..))
     }
 }
 
 impl<'a> From<VirtualSpan<'a>> for Span<'a> {
     fn from(value: VirtualSpan<'a>) -> Self {
         let span = match value {
-            VirtualSpan::Synthetic(span) | VirtualSpan::Content(span, _) => span,
+            VirtualSpan::Synthetic(span)
+            | VirtualSpan::WrapMarker(span)
+            | VirtualSpan::Content(span, _) => span,
         };
         // Expand tabs so the terminal doesn't break the layout; the cursor maps
         // by byte offset against the un-expanded content (tabs counted as two).
@@ -126,6 +145,10 @@ impl<'a> VirtualLine<'a> {
         VirtualLine {
             spans: spans.to_vec(),
         }
+    }
+
+    pub fn is_wrap_continuation(&self) -> bool {
+        self.spans.iter().any(VirtualSpan::is_wrap_marker)
     }
 
     pub fn spans(self) -> Vec<Span<'a>> {

--- a/basalt/vim.toml
+++ b/basalt/vim.toml
@@ -2,6 +2,8 @@
 key_bindings = [
   { key = "k", command = "note_editor_cursor_up" },
   { key = "j", command = "note_editor_cursor_down" },
+  { key = "gk", command = "note_editor_cursor_screen_up" },
+  { key = "gj", command = "note_editor_cursor_screen_down" },
   { key = "up", command = "note_editor_cursor_up" },
   { key = "down", command = "note_editor_cursor_down" },
   { key = "tab", command = "note_editor_switch_pane_next" },


### PR DESCRIPTION
`j`/`k` move by whole soft-wrapped lines, matching Vim. On the first line `k` goes to line start; on the last line `j` goes to line end. New `gj`/`gk` move by single visible rows. Screen movement drives half-page scroll and jump-to-top so the viewport tracks rows.

Wrap continuation is derived from a typed `VirtualSpan::WrapMarker` span produced only by render, replacing the stored `wrap_continuation` flag.