### PR TITLE
Configurable line wrapping and current-line highlight

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -14,6 +14,18 @@
 > Wrap continuation is derived from a typed VirtualSpan::WrapMarker span
 > produced only by render, replacing the stored wrap_continuation flag.
 
+- [18bc817](https://github.com/erikjuhani/basalt/commit/18bc8171481d8d16b59983ead37b05ba1202ca12) Make note editor line wrapping configurable by @erikjuhani
+
+> Wrapping suits prose, but tables and code read better unwrapped. Add a
+> `wrap` toggle (default on); when off, a long line pans horizontally like
+> code lines already do.
+
+- [8832bc4](https://github.com/erikjuhani/basalt/commit/8832bc4691fd491d8caf50b689d64229a10fd865) Highlight the cursor's line in the note editor by @erikjuhani
+
+> Tracking the cursor across wrapped rows is hard. Tint the whole logical
+> line instead, in read and edit mode, replacing the heavier read-mode
+> reverse bar. The `line-highlight` theme key sets the colour or turns it off.
+
 ### Changed
 
 - [27bdefa](https://github.com/erikjuhani/basalt/commit/27bdefa3cc2b7d98380ec4577f29d45ecb25029e) Memoize note layout instead of rebuilding it every frame by @erikjuhani

--- a/basalt/config.toml
+++ b/basalt/config.toml
@@ -132,6 +132,8 @@
 experimental_editor = false
 vim_mode = false
 
+wrap = true
+
 # The key that `<leader>` stands for in key bindings, e.g. `{ key =
 # "<leader>f", command = "vault_selector_modal_toggle" }`. Only the leader set
 # in the user config takes effect.

--- a/basalt/src/app.rs
+++ b/basalt/src/app.rs
@@ -803,6 +803,7 @@ impl<'a> App<'a> {
                     );
                     editor.set_vim_mode(config.vim_mode);
                     editor.set_editor_enabled(config.experimental_editor);
+                    editor.set_wrap(config.wrap);
                     if config.experimental_editor && config.vim_mode {
                         editor.set_view(View::Edit(EditMode::Source));
                     } else {

--- a/basalt/src/config/mod.rs
+++ b/basalt/src/config/mod.rs
@@ -88,6 +88,7 @@ impl fmt::Display for ConfigSection<'_> {
 pub struct Config<'a> {
     pub experimental_editor: bool,
     pub vim_mode: bool,
+    pub wrap: bool,
     pub symbols: Symbols,
     pub theme: Theme,
     pub global: ConfigSection<'a>,
@@ -138,6 +139,7 @@ impl Config<'_> {
             theme: theme::theme_by_name(value.theme.as_deref().unwrap_or("default")),
             experimental_editor: value.experimental_editor,
             vim_mode: value.vim_mode,
+            wrap: value.wrap.unwrap_or(true),
             global: ConfigSection::from_toml(value.global, leader),
             splash: ConfigSection::from_toml(value.splash, leader),
             explorer: ConfigSection::from_toml(value.explorer, leader),
@@ -158,6 +160,7 @@ impl Config<'_> {
         self.theme = config.theme;
         self.experimental_editor = config.experimental_editor;
         self.vim_mode = config.vim_mode;
+        self.wrap = config.wrap;
         self.global.merge_key_bindings(config.global);
         self.explorer.merge_key_bindings(config.explorer);
         self.splash.merge_key_bindings(config.splash);
@@ -267,6 +270,8 @@ struct TomlConfig {
     experimental_editor: bool,
     #[serde(default)]
     vim_mode: bool,
+    #[serde(default)]
+    wrap: Option<bool>,
     #[serde(default)]
     leader: Leader,
     #[serde(default)]

--- a/basalt/src/config/symbol.rs
+++ b/basalt/src/config/symbol.rs
@@ -94,6 +94,8 @@ pub struct Symbols {
     pub title_font_style: Option<FontStyle>,
     pub h5_font_style: Option<FontStyle>,
     pub h6_font_style: Option<FontStyle>,
+    #[serde(skip)]
+    pub wrap: bool,
 }
 
 impl From<TomlSymbols> for Symbols {
@@ -235,6 +237,7 @@ impl Default for Symbols {
             title_font_style: None,
             h5_font_style: None,
             h6_font_style: None,
+            wrap: true,
         }
     }
 }
@@ -302,6 +305,7 @@ impl Symbols {
             title_font_style: Some(FontStyle::BlackBoardBold),
             h5_font_style: Some(FontStyle::Script),
             h6_font_style: Some(FontStyle::Script),
+            wrap: true,
         }
     }
 
@@ -363,6 +367,7 @@ impl Symbols {
             title_font_style: Some(FontStyle::BlackBoardBold),
             h5_font_style: Some(FontStyle::Script),
             h6_font_style: Some(FontStyle::Script),
+            wrap: true,
         }
     }
 

--- a/basalt/src/config/theme.rs
+++ b/basalt/src/config/theme.rs
@@ -32,6 +32,7 @@ pub struct Theme {
     pub heading_6: Color,
     /// Background for fenced code blocks.
     pub code_bg: Color,
+    pub line_highlight: Option<Color>,
     /// Block-quote bar and text.
     pub blockquote: Color,
     /// List bullets and ordered-list numbers.
@@ -187,6 +188,7 @@ impl Default for Theme {
             heading_5: Color::Reset,
             heading_6: Color::Reset,
             code_bg: Color::Black,
+            line_highlight: None,
             blockquote: Color::Magenta,
             list_marker: Color::DarkGray,
             task: Color::Magenta,
@@ -248,6 +250,7 @@ struct TomlTheme {
     heading_5: Option<String>,
     heading_6: Option<String>,
     code_bg: Option<String>,
+    line_highlight: Option<String>,
     blockquote: Option<String>,
     list_marker: Option<String>,
     task: Option<String>,
@@ -295,6 +298,16 @@ fn resolve(palette: &HashMap<String, String>, role: Option<String>, fallback: Co
     .unwrap_or(fallback)
 }
 
+fn darken(color: Color) -> Color {
+    match color {
+        Color::Rgb(r, g, b) => {
+            let scale = |channel: u8| (channel as f32 * 0.8) as u8;
+            Color::Rgb(scale(r), scale(g), scale(b))
+        }
+        _ => Color::Black,
+    }
+}
+
 fn resolve_pane(palette: &HashMap<String, String>, toml: TomlPane, default: Pane) -> Pane {
     Pane {
         background: resolve(palette, toml.background, default.background),
@@ -338,6 +351,11 @@ impl From<TomlTheme> for Theme {
             heading_5: color(value.heading_5, default.heading_5),
             heading_6: color(value.heading_6, default.heading_6),
             code_bg: color(value.code_bg, default.code_bg),
+            line_highlight: if value.line_highlight.as_deref() == Some("none") {
+                None
+            } else {
+                Some(color(value.line_highlight, darken(background)))
+            },
             blockquote: color(value.blockquote, default.blockquote),
             list_marker: color(value.list_marker, default.list_marker),
             task: color(value.task, default.task),

--- a/basalt/src/note_editor/cursor.rs
+++ b/basalt/src/note_editor/cursor.rs
@@ -1,17 +1,8 @@
 use std::ops::ControlFlow;
 
-use ratatui::{
-    buffer::Buffer,
-    layout::{Offset, Rect},
-    style::{Color, Style},
-    widgets::StatefulWidget,
-};
 use unicode_width::UnicodeWidthChar;
 
-use crate::{
-    config::Theme,
-    note_editor::{text_buffer::TextBuffer, virtual_document::VirtualLine},
-};
+use crate::note_editor::{text_buffer::TextBuffer, virtual_document::VirtualLine};
 
 #[derive(Clone, Debug)]
 pub enum Message {
@@ -386,63 +377,6 @@ impl Cursor {
 
     pub fn virtual_column(&self) -> usize {
         self.virtual_column
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct CursorWidget {
-    offset: Offset,
-    meta_len: u16,
-    selection: Color,
-}
-
-impl Default for CursorWidget {
-    fn default() -> Self {
-        Self {
-            offset: Offset::default(),
-            meta_len: 0,
-            selection: Theme::default().muted,
-        }
-    }
-}
-
-impl CursorWidget {
-    pub fn with_offset(mut self, offset: Offset) -> Self {
-        self.offset = offset;
-        self
-    }
-
-    pub fn with_meta_len(mut self, meta_len: u16) -> Self {
-        self.meta_len = meta_len;
-        self
-    }
-
-    pub fn with_theme(mut self, theme: &Theme) -> Self {
-        self.selection = theme.muted;
-        self
-    }
-}
-
-impl StatefulWidget for CursorWidget {
-    type State = Cursor;
-
-    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State)
-    where
-        Self: Sized,
-    {
-        if !matches!(state.mode, CursorMode::Read) {
-            return;
-        }
-
-        let y = (state.virtual_row as u16)
-            .saturating_add(self.meta_len)
-            .saturating_sub(area.top())
-            .saturating_add(self.offset.y as u16);
-
-        buf.set_style(
-            Rect::new(self.offset.x as u16, y, area.width, 1),
-            Style::default().reversed().fg(self.selection),
-        );
     }
 }
 

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, ops::Range};
 
 use ratatui::{
     buffer::Buffer,
-    layout::{Offset, Position, Rect},
+    layout::{Position, Rect},
     style::{Color, Style, Stylize},
     text::{Line, Span},
     widgets::{
@@ -13,10 +13,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthChar;
 
 use crate::note_editor::{
-    cursor::{CursorMode, CursorWidget},
-    state::NoteEditorState,
-    viewport::Viewport,
-    virtual_document::VirtualLine,
+    cursor::CursorMode, state::NoteEditorState, viewport::Viewport, virtual_document::VirtualLine,
 };
 
 const SELECTION_STYLE: Style = Style::new().reversed();
@@ -81,6 +78,38 @@ fn render_highlight(
                 }
                 col += span.width() as u16;
             }
+        });
+}
+
+fn render_line_highlight(
+    buf: &mut Buffer,
+    inner_area: Rect,
+    viewport: &Viewport,
+    meta: &[VirtualLine],
+    doc: &[VirtualLine],
+    range: &Range<usize>,
+    bg: Color,
+) {
+    let meta_len = meta.len();
+    let viewport_top = viewport.top() as usize;
+    let style = Style::new().bg(bg);
+    // The next logical line starts past `range.end`, so an inclusive test on a
+    // row's source start also catches the one row of an empty line.
+    let line_span = range.start..=range.end;
+    let starts_in_line = |line: &&VirtualLine| {
+        line.source_range()
+            .is_some_and(|source| line_span.contains(&source.start))
+    };
+
+    meta.iter()
+        .chain(doc.iter())
+        .enumerate()
+        .skip(viewport_top)
+        .take(inner_area.height as usize)
+        .filter(|(idx, line)| *idx >= meta_len && starts_in_line(line))
+        .for_each(|(idx, _)| {
+            let y = inner_area.y + (idx - viewport_top) as u16;
+            buf.set_style(Rect::new(inner_area.x, y, inner_area.width, 1), style);
         });
 }
 
@@ -157,6 +186,20 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
             .block(block)
             .render(area, buf);
 
+        if !state.content.is_empty() || state.is_editing() {
+            if let Some(bg) = theme.line_highlight {
+                render_line_highlight(
+                    buf,
+                    inner_area,
+                    state.viewport(),
+                    meta,
+                    doc,
+                    &state.line_highlight_range(),
+                    bg,
+                );
+            }
+        }
+
         if let Some(range) = state.selection_range() {
             render_highlight(
                 buf,
@@ -181,30 +224,20 @@ impl<'a> StatefulWidget for NoteEditor<'a> {
             );
         }
 
+        // Read mode marks the cursor's line with the line-highlight tint, so
+        // only edit mode places a terminal cursor.
         state.terminal_cursor = None;
-        if !state.content.is_empty() || state.is_editing() {
-            match *state.cursor.mode() {
-                CursorMode::Read => CursorWidget::default()
-                    .with_offset(Offset {
-                        x: inner_area.x as i32,
-                        y: inner_area.y as i32,
-                    })
-                    .with_meta_len(meta_lines_count as u16)
-                    .with_theme(&theme)
-                    .render(state.viewport().area(), buf, &mut state.cursor),
-                CursorMode::Edit => {
-                    let scroll = state.viewport().area();
-                    let y = (state.cursor.virtual_row() as u16)
-                        .saturating_add(meta_lines_count as u16)
-                        .saturating_sub(scroll.top())
-                        .saturating_add(inner_area.y);
-                    let x = (state.cursor.virtual_column() as u16)
-                        .saturating_add(inner_area.x)
-                        .saturating_sub(scroll.left());
-                    let position = Position { x, y };
-                    state.terminal_cursor = inner_area.contains(position).then_some(position);
-                }
-            }
+        if let CursorMode::Edit = *state.cursor.mode() {
+            let scroll = state.viewport().area();
+            let y = (state.cursor.virtual_row() as u16)
+                .saturating_add(meta_lines_count as u16)
+                .saturating_sub(scroll.top())
+                .saturating_add(inner_area.y);
+            let x = (state.cursor.virtual_column() as u16)
+                .saturating_add(inner_area.x)
+                .saturating_sub(scroll.left());
+            let position = Position { x, y };
+            state.terminal_cursor = inner_area.contains(position).then_some(position);
         }
 
         if !area.is_empty() && total_lines as u16 > inner_area.bottom() {
@@ -936,6 +969,140 @@ mod tests {
         assert!(
             highlighted,
             "the prettified list marker on a selected line should be highlighted"
+        );
+    }
+
+    #[test]
+    fn test_line_highlight_tints_every_wrapped_row_in_edit_mode() {
+        use crate::config::Theme;
+        use ratatui::layout::Size;
+
+        let tint = Color::Rgb(1, 2, 3);
+        let content =
+            "short first line\nsecond line long enough to wrap across the editor width for sure\nthird\n";
+        let mut state =
+            NoteEditorState::new(content, "", Path::new("test.md"), &Symbols::unicode());
+        let theme = Theme {
+            line_highlight: Some(tint),
+            ..Theme::default()
+        };
+        state.set_theme(&theme);
+        state.set_editor_enabled(true);
+        state.resize_viewport(Size::new(30, 12));
+        state.set_view(View::Edit(EditMode::Source));
+
+        state.cursor_down(1);
+
+        let mut terminal = Terminal::new(TestBackend::new(30, 12)).unwrap();
+        terminal
+            .draw(|frame| {
+                NoteEditor::default().render(frame.area(), frame.buffer_mut(), &mut state)
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let tinted_rows: std::collections::BTreeSet<u16> = (0..buffer.area.height)
+            .filter(|&y| {
+                (0..buffer.area.width).any(|x| buffer.cell((x, y)).is_some_and(|c| c.bg == tint))
+            })
+            .collect();
+
+        assert!(
+            tinted_rows.len() >= 2,
+            "the wrapped current line should tint each of its rows, got {tinted_rows:?}",
+        );
+        assert!(
+            tinted_rows
+                .iter()
+                .zip(tinted_rows.iter().skip(1))
+                .all(|(a, b)| b - a == 1),
+            "the tinted rows should be contiguous, got {tinted_rows:?}",
+        );
+    }
+
+    #[test]
+    fn test_line_highlight_marks_the_cursor_line_in_read_mode() {
+        use crate::config::Theme;
+        use ratatui::layout::Size;
+
+        let tint = Color::Rgb(4, 5, 6);
+        let mut state = NoteEditorState::new(
+            "first line\nsecond line\nthird line\n",
+            "",
+            Path::new("test.md"),
+            &Symbols::unicode(),
+        );
+        let theme = Theme {
+            line_highlight: Some(tint),
+            ..Theme::default()
+        };
+        state.set_theme(&theme);
+        state.resize_viewport(Size::new(30, 12));
+        state.cursor_down(1);
+
+        let mut terminal = Terminal::new(TestBackend::new(30, 12)).unwrap();
+        terminal
+            .draw(|frame| {
+                NoteEditor::default().render(frame.area(), frame.buffer_mut(), &mut state)
+            })
+            .unwrap();
+
+        let tinted = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .any(|c| c.bg == tint);
+
+        assert!(
+            tinted,
+            "read mode should tint the cursor's line with the line-highlight colour",
+        );
+    }
+
+    #[test]
+    fn test_line_highlight_can_be_disabled() {
+        use crate::config::Theme;
+        use ratatui::layout::Size;
+
+        let mut state = NoteEditorState::new(
+            "alpha\nbeta\n",
+            "",
+            Path::new("test.md"),
+            &Symbols::unicode(),
+        );
+        let theme = Theme {
+            line_highlight: None,
+            ..Theme::default()
+        };
+        state.set_theme(&theme);
+        state.set_editor_enabled(true);
+        state.resize_viewport(Size::new(30, 8));
+        state.set_view(View::Edit(EditMode::Source));
+
+        let mut terminal = Terminal::new(TestBackend::new(30, 8)).unwrap();
+        terminal
+            .draw(|frame| {
+                NoteEditor::default().render(frame.area(), frame.buffer_mut(), &mut state)
+            })
+            .unwrap();
+
+        let default_bg = terminal
+            .backend()
+            .buffer()
+            .cell((0, 0))
+            .map(|c| c.bg)
+            .unwrap();
+        let all_base_bg = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .all(|c| c.bg == default_bg);
+
+        assert!(
+            all_base_bg,
+            "a `none` tint should leave every row on the base background"
         );
     }
 }

--- a/basalt/src/note_editor/render.rs
+++ b/basalt/src/note_editor/render.rs
@@ -66,7 +66,8 @@ fn text_wrap_internal<'a>(
     symbols: &Symbols,
 ) -> Vec<VirtualLine<'a>> {
     let wrap_marker = &symbols.wrap_marker;
-    let wrapped_lines = wrap_preserve_trailing(text_content, width, wrap_marker.width() + 1);
+    let wrap_width = if symbols.wrap { width } else { usize::MAX };
+    let wrapped_lines = wrap_preserve_trailing(text_content, wrap_width, wrap_marker.width() + 1);
 
     let mut current_range_start = source_range.start;
 

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -273,6 +273,10 @@ impl<'a> NoteEditorState<'a> {
         self.editor_enabled = enabled;
     }
 
+    pub fn set_wrap(&mut self, wrap: bool) {
+        self.virtual_document.set_wrap(wrap);
+    }
+
     pub fn text_buffer(&self) -> Option<&TextBuffer> {
         self.text_buffer.as_ref()
     }
@@ -1919,6 +1923,30 @@ mod tests {
         state.resize_viewport(Size::new(40, 10));
         state.set_view(View::Edit(EditMode::Source));
         state
+    }
+
+    #[test]
+    fn test_wrap_disabled_keeps_line_on_one_row_and_pans() {
+        let content = "hello world foobar baz qux quux corge grault\n";
+        let mut state =
+            NoteEditorState::new(content, "test", Path::new("test.md"), &Symbols::unicode());
+        state.set_wrap(false);
+        state.resize_viewport(Size::new(12, 20));
+        state.set_view(View::Edit(EditMode::Source));
+
+        assert_eq!(state.viewport().left(), 0, "no scroll at line start");
+
+        state.cursor_right(100);
+        assert_eq!(
+            state.cursor.virtual_row(),
+            0,
+            "with wrap off the line stays on a single row",
+        );
+        assert!(
+            state.viewport().left() > 0,
+            "with wrap off a long line pans horizontally to follow the cursor",
+        );
+        assert_cursor_visible(&state, "at the end of the unwrapped line");
     }
 
     #[test]

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -859,6 +859,16 @@ impl<'a> NoteEditorState<'a> {
         Some(range)
     }
 
+    pub fn line_highlight_range(&self) -> Range<usize> {
+        let content = self.live_content();
+        let cursor = self.cursor.source_offset().min(content.len());
+        let start = content[..cursor].rfind('\n').map_or(0, |i| i + 1);
+        let end = content[cursor..]
+            .find('\n')
+            .map_or(content.len(), |i| cursor + i);
+        start..end
+    }
+
     pub fn selected_text(&self) -> Option<String> {
         let range = self.selection_range()?;
         self.live_content().get(range).map(str::to_string)

--- a/basalt/src/note_editor/virtual_document.rs
+++ b/basalt/src/note_editor/virtual_document.rs
@@ -261,6 +261,10 @@ impl<'a> VirtualDocument<'a> {
             self.cache_key = None;
         }
     }
+
+    pub fn set_wrap(&mut self, wrap: bool) {
+        self.symbols.wrap = wrap;
+    }
     pub fn meta(&self) -> &[VirtualLine<'_>] {
         &self.meta
     }

--- a/basalt/themes/catppuccin-frappe.toml
+++ b/basalt/themes/catppuccin-frappe.toml
@@ -19,6 +19,7 @@ heading-5 = "green"
 heading-6 = "peach"
 
 code-bg = "surface0"
+line-highlight = "mantle"
 blockquote = "sapphire"
 list-marker = "mauve"
 task = "green"

--- a/basalt/themes/catppuccin-latte.toml
+++ b/basalt/themes/catppuccin-latte.toml
@@ -19,6 +19,7 @@ heading-5 = "green"
 heading-6 = "peach"
 
 code-bg = "surface0"
+line-highlight = "mantle"
 blockquote = "sapphire"
 list-marker = "mauve"
 task = "green"

--- a/basalt/themes/catppuccin-macchiato.toml
+++ b/basalt/themes/catppuccin-macchiato.toml
@@ -19,6 +19,7 @@ heading-5 = "green"
 heading-6 = "peach"
 
 code-bg = "surface0"
+line-highlight = "mantle"
 blockquote = "sapphire"
 list-marker = "mauve"
 task = "green"

--- a/basalt/themes/catppuccin-mocha.toml
+++ b/basalt/themes/catppuccin-mocha.toml
@@ -19,6 +19,7 @@ heading-5 = "green"
 heading-6 = "peach"
 
 code-bg = "surface0"
+line-highlight = "mantle"
 blockquote = "sapphire"
 list-marker = "mauve"
 task = "green"

--- a/basalt/themes/default.toml
+++ b/basalt/themes/default.toml
@@ -18,6 +18,7 @@ heading-5 = "reset"
 heading-6 = "reset"
 
 code-bg = "black"
+line-highlight = "none"
 blockquote = "magenta"
 list-marker = "darkgray"
 task = "magenta"


### PR DESCRIPTION
Two note editor changes:

- **Configurable wrapping.** A `wrap` toggle (default on). When off, long lines pan horizontally like code lines.
- **Current-line highlight.** Tint the cursor's logical line in read and edit mode, replacing the read-mode reverse bar. Set with the `line-highlight` theme key, or turn off with `"none"`.