### PR TITLE
Make blank lines between blocks editable in edit mode

### DIFF
--- a/basalt/CHANGELOG.md
+++ b/basalt/CHANGELOG.md
@@ -42,6 +42,12 @@
 
 ### Fixed
 
+- [8e0fa5a](https://github.com/erikjuhani/basalt/commit/8e0fa5aa5243b23f5b4050b2925c5fba15a17098) Make blank lines between blocks editable in edit mode by @erikjuhani
+
+> The cursor could not reach the blank lines that separate blocks. Blocks
+> now tile the document, so the block above a blank line owns it. The
+> cursor can rest on and edit those blanks.
+
 - [28429e2](https://github.com/erikjuhani/basalt/commit/28429e2440fca596a1470fe6caca9bf424a1ad03) Match title text to the symbol preset by @erikjuhani
 
 > The `⋅𝕭𝖆𝖘𝖆𝖑𝖙⋅` title was hardcoded in the header and the splash modal,

--- a/basalt/src/note_editor/editor.rs
+++ b/basalt/src/note_editor/editor.rs
@@ -599,6 +599,7 @@ mod tests {
                     state.resize_viewport(area.as_size());
                     state.set_view(View::Edit(EditMode::Source));
                     state.cursor_down(1);
+                    state.cursor_down(1);
                     state
                 }),
             ),
@@ -623,6 +624,7 @@ mod tests {
                     );
                     state.resize_viewport(area.as_size());
                     state.set_view(View::Edit(EditMode::Source));
+                    state.cursor_down(1);
                     state.cursor_down(1);
                     state
                 }),
@@ -649,6 +651,7 @@ mod tests {
                     state.resize_viewport(area.as_size());
                     state.set_view(View::Edit(EditMode::Source));
                     // Onto the delimiter row, then delete its second column.
+                    state.cursor_down(1);
                     state.cursor_down(1);
                     state.cursor_down(1);
                     state.cursor_right(40);
@@ -682,6 +685,7 @@ mod tests {
                     state.set_view(View::Edit(EditMode::Source));
                     state.cursor_down(1);
                     state.cursor_down(1);
+                    state.cursor_down(1);
                     state
                 }),
             ),
@@ -704,6 +708,7 @@ mod tests {
                     );
                     state.resize_viewport(area.as_size());
                     state.set_view(View::Edit(EditMode::Source));
+                    state.cursor_down(1);
                     state.cursor_down(1);
                     state.cursor_down(1);
                     state.cursor_down(1);
@@ -731,6 +736,7 @@ mod tests {
                     state.set_view(View::Edit(EditMode::Source));
                     // Enter the list (lands on the first item), then step down to
                     // the "bananas" item.
+                    state.cursor_down(1);
                     state.cursor_down(1);
                     state.cursor_down(1);
                     state

--- a/basalt/src/note_editor/state.rs
+++ b/basalt/src/note_editor/state.rs
@@ -281,15 +281,39 @@ impl<'a> NoteEditorState<'a> {
         self.text_buffer.as_ref()
     }
 
+    fn block_source_range(&self, block_idx: usize) -> Option<Range<usize>> {
+        let node = self.ast_nodes.get(block_idx)?;
+        let start = if block_idx == 0 {
+            0
+        } else {
+            node.source_range().start
+        };
+        let end = self
+            .ast_nodes
+            .get(block_idx + 1)
+            .map(|next| next.source_range().start)
+            .unwrap_or(self.content.len())
+            .max(node.source_range().end);
+        Some(start..end)
+    }
+
+    fn block_index_for_offset(&self, offset: usize) -> Option<usize> {
+        (!self.ast_nodes.is_empty()).then(|| {
+            self.ast_nodes
+                .iter()
+                .rposition(|node| node.source_range().start <= offset)
+                .unwrap_or(0)
+        })
+    }
+
     pub fn enter_insert(&mut self, block_idx: usize) {
         // Commit any pending edits from the previous block before switching.
         self.commit_text_buffer();
 
         self.editing_block = Some(block_idx);
-        if let Some(node) = self.ast_nodes.get(block_idx) {
-            let source_range = node.source_range();
+        if let Some(source_range) = self.block_source_range(block_idx) {
             if let Some(content) = self.content.get(source_range.clone()) {
-                self.text_buffer = Some(TextBuffer::new(content, source_range.clone()));
+                self.text_buffer = Some(TextBuffer::new(content, source_range));
             }
         } else if self.content.is_empty() {
             // Only create an empty node for genuinely empty files, not when
@@ -950,42 +974,9 @@ impl<'a> NoteEditorState<'a> {
         let offset = cursor::snap_to_char_boundary(&self.content, offset);
 
         if matches!(self.view, View::Edit(..)) {
-            let target_block = self
-                .ast_nodes
-                .iter()
-                .position(|node| node.source_range().contains(&offset))
-                .or_else(|| {
-                    self.ast_nodes
-                        .iter()
-                        .position(|node| node.source_range().start >= offset)
-                })
-                .or_else(|| {
-                    self.ast_nodes
-                        .iter()
-                        .rposition(|node| node.source_range().end <= offset)
-                });
-            if let Some(block) = target_block {
+            if let Some(block) = self.block_index_for_offset(offset) {
                 if self.editing_block != Some(block) {
                     self.enter_insert(block);
-                }
-                // The leading whitespace a change leaves before a block is not
-                // inside any block's range; extend the buffer back over that gap so
-                // inserts land at the cursor. Only bridge whitespace — never block
-                // markers (list bullets, quote glyphs).
-                if let Some(start) = self.text_buffer.as_ref().map(|b| b.source_range.start) {
-                    let end = self
-                        .text_buffer
-                        .as_ref()
-                        .map_or(start, |b| b.source_range.end);
-                    let gap_is_blank = self
-                        .content
-                        .get(offset..start)
-                        .is_some_and(|gap| gap.chars().all(|c| c == ' ' || c == '\t'));
-                    if offset < start && gap_is_blank {
-                        if let Some(text) = self.content.get(offset..end) {
-                            self.text_buffer = Some(TextBuffer::new(text, offset..end));
-                        }
-                    }
                 }
             }
         }
@@ -1016,14 +1007,7 @@ impl<'a> NoteEditorState<'a> {
         if matches!(self.view, View::Edit(..)) && self.text_buffer.is_none() {
             let offset = self.cursor.source_offset();
             let block_idx = self
-                .ast_nodes
-                .iter()
-                .position(|node| node.source_range().contains(&offset))
-                .or_else(|| {
-                    self.ast_nodes
-                        .iter()
-                        .rposition(|node| node.source_range().end <= offset)
-                })
+                .block_index_for_offset(offset)
                 .unwrap_or_else(|| self.current_block_idx());
             self.enter_insert(block_idx);
             self.cursor.update(
@@ -1126,8 +1110,7 @@ impl<'a> NoteEditorState<'a> {
         let moved_up = target_block_idx < prev_block_idx;
         let use_end = adjacent && moved_up;
 
-        let target_offset = self.ast_nodes.get(target_block_idx).map(|node| {
-            let range = node.source_range();
+        let target_offset = self.block_source_range(target_block_idx).map(|range| {
             if use_end {
                 range.end.saturating_sub(1).max(range.start)
             } else {
@@ -1737,6 +1720,34 @@ mod tests {
         state.delete_char();
         state.commit_text_buffer();
         assert_eq!(state.content, "- a\n- b\n");
+    }
+
+    #[test]
+    fn test_blank_line_between_paragraphs_is_reachable() {
+        let mut state = NoteEditorState::new(
+            "para one\n\npara two\n",
+            "test",
+            Path::new("test.md"),
+            &Symbols::unicode(),
+        );
+        state.resize_viewport(Size::new(40, 12));
+        state.set_view(View::Edit(EditMode::Source));
+
+        state.cursor_down(1);
+        assert_eq!(state.cursor.source_offset(), 9);
+        assert_eq!(state.current_block_idx(), 0);
+
+        state.cursor_down(1);
+        assert_eq!(state.cursor.source_offset(), 10);
+        assert_eq!(state.current_block_idx(), 1);
+
+        state.cursor_up(1);
+        assert_eq!(state.cursor.source_offset(), 9);
+        assert_eq!(state.current_block_idx(), 0);
+
+        state.delete_char();
+        state.commit_text_buffer();
+        assert_eq!(state.content, "para one\npara two\n");
     }
 
     /// Pressing Enter at the very start of a list item must insert a blank line


### PR DESCRIPTION
Blocks now tile the document: each block's editable span runs from its start to the next block's start, so the preceding block owns the blank lines that follow it. The cursor can rest on and edit those blanks, which previously fell in an unreachable gap between block source ranges.