### PR TITLE
Ignore zizmor self-repository audit for local reusable workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
   build:
     needs: check
     if: github.event_name == 'workflow_dispatch' || needs.check.outputs.changed == 'true'
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build.yml # zizmor: ignore[self-repository]
     with:
       version: nightly
       channel: nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions: {}
 
 jobs:
   build:
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build.yml # zizmor: ignore[self-repository]
 
   release:
     name: Release


### PR DESCRIPTION
## Summary

Unblocks #655. zizmor 1.30.0 adds a `self-repository` audit that flags `uses: ./.github/workflows/build.yml` in `nightly.yml` and `release.yml`. The pedantic persona treats it as a finding, so the Security job fails on the version bump.

zizmor recommends the `$/.github/workflows/build.yml` form. actionlint (latest, v1.7.12, and its `main` branch) rejects that form, so switching the syntax only moves the failure to the actionlint step.

This PR keeps the working `./` form and adds `# zizmor: ignore[self-repository]` on the two lines.

## Verification

Run locally against the changed workflows:

- zizmor 1.30.0 (docker, `--persona pedantic --min-severity low`): no findings, 2 ignored
- actionlint 1.7.7 with `-ignore SC2153`: clean
- pinact `run --check`: clean

After this merges, rebase #655 so its Security check reruns.
